### PR TITLE
Fixed the relaxed state symmetry script for the multistate case

### DIFF
--- a/tutorials/morph_tree/scripts/mkv_model_gamma_discretized_multistate.Rev
+++ b/tutorials/morph_tree/scripts/mkv_model_gamma_discretized_multistate.Rev
@@ -4,12 +4,12 @@
 #
 # This file: Specifies the discretized morphological substitution model  ...
 #
-# authors:  April M. Wright, Michael J. Landis, Sebastian Höhna
+# authors:  April M. Wright, Michael J. Landis, Sebastian Höhna, David Černý
 #
 ################################################################################
 ################################################################################
 
-# Specify the two parameters to the Beta distribution, and the moves on these parameters.
+# Set the two parameters to the beta distribution equal to each other, and a move to operate on them.
 beta_scale ~ dnLognormal( 0.0, sd=2*0.587405 )
 moves.append( mvScale(beta_scale, lambda=1, weight=5.0 ) )
 
@@ -19,6 +19,10 @@ rates_morpho := fnDiscretizeGamma( alpha_morpho, alpha_morpho, 4 )
 
 # Moves on the parameters to the Gamma distribution.
 moves.append( mvScale(alpha_morpho, lambda=1, weight=2.0) )
+
+# How many distinct matrices we want in the mixture, not including their symmetric counterparts.
+n_cats = 3
+iter_vect = seq(from = 1, to = 2*n_cats, by = 2)
 
 n_max_states <- 7
 idx = 1
@@ -30,25 +34,39 @@ for (i in 2:n_max_states) {
     nc = morpho_bystate[i].nchar()                             # get number of characters per character size with i-sized states
     if (nc > 0) {
       i
-      for (j in 1:i)
-      {
-        Q[idx][j] := fnF81(simplex(fnDiscretizeBeta(beta_scale, beta_scale, i)))
-      } # make i-by-i rate matrix
+      for (j in iter_vect) {
+          beta_scale.redraw()
+          
+          pi_prior := fnDiscretizeBeta(beta_scale, beta_scale, i)
+          
+          # reverse the pi_prior vector
+          for (k in 1:pi_prior.size()) {
+              upper = pi_prior.size()
+              ind = upper + 1 - k
+              rev_pi_prior[k] <- pi_prior[ind]
+          }
+          
+          # create i-by-i rate matrices from both the original and reversed pi_prior vectors
+          Q[idx][j] := fnF81(simplex(pi_prior))
+          Q[idx][j+1] := fnF81(simplex(rev_pi_prior))
+          
+          Q[idx][j]
+          print(" ")
+          Q[idx][j+1]
+          print(" ")
+      }
 
-      # Tell the model what the probability of a character going into any particular category.
-      # This prior says that a character is equally likely to be put into any category.
-      mat_prior[idx] <- rep(1, i)
+      mat_prior[idx] <- rep(1, 2*n_cats)
       matrix_probs[idx] ~ dnDirichlet(mat_prior[idx])
 
       moves.append( mvBetaSimplex(matrix_probs[idx], weight=3.0) )
       moves.append( mvDirichletSimplex(matrix_probs[idx], weight=1.5) )
 
-      m_morph[idx] ~ dnPhyloCTMC(tree=phylogeny, siteRates=rates_morpho,
-                              Q=Q[idx], type="Standard",
-                              siteMatrices=matrix_probs[idx])
+      m_morph[idx] ~ dnPhyloCTMC(tree=phylogeny, siteRates=rates_morpho, Q=Q[idx],
+                                 type="Standard", siteMatrices=matrix_probs[idx])
       m_morph[idx].clamp(morpho_bystate[i])
 
-      idx = idx + 1                                          # increment counter
+      idx = idx + 1                                            # increment counter
       idx
     }
 }


### PR DESCRIPTION
Changed the `mkv_model_gamma_discretized_multistate.Rev` script in tutorials/morph_tree to ensure that the vector of Q matrices is symmetric and that its elements are mutually different.