### PR TITLE
Fixed SHDM code in the Discrete Morphology tutorial

### DIFF
--- a/tutorials/morph_tree/scripts/mkv_model_gamma_discretized_multistate.Rev
+++ b/tutorials/morph_tree/scripts/mkv_model_gamma_discretized_multistate.Rev
@@ -9,64 +9,82 @@
 ################################################################################
 ################################################################################
 
-# Set the two parameters to the beta distribution equal to each other, and a move to operate on them.
-beta_scale ~ dnLognormal( 0.0, sd=2*0.587405 )
-moves.append( mvScale(beta_scale, lambda=1, weight=5.0 ) )
+# Draw the concentration parameter of the Dirichlet distribution of equilibrium state
+# frequencies from an exponential hyperprior, and place a move on it.
+dir_alpha ~ dnExponential( 1.0 )
+moves.append( mvSlice(dir_alpha, weight=5.0 ) )
 
-# Set up Gamma-distributed rate variation.
+# Set up gamma-distributed rate variation.
 alpha_morpho ~ dnUniform( 0.0, 1E6 )
 rates_morpho := fnDiscretizeGamma( alpha_morpho, alpha_morpho, 4 )
 
-# Moves on the parameters to the Gamma distribution.
-moves.append( mvScale(alpha_morpho, lambda=1, weight=2.0) )
+# Move on the shape parameter of the gamma distribution.
+moves.append( mvSlice(alpha_morpho, weight=2.0) )
 
-# How many distinct matrices we want in the mixture, not including their symmetric counterparts.
+# How many distinct rate matrices we want in the mixture. Note that since we have to
+# create a symmetric counterpart for each matrix, the total number is going to equal
+# twice the value specified below.
 n_cats = 3
-iter_vect = seq(from = 1, to = 2*n_cats, by = 2)
 
 n_max_states <- 7
 idx = 1
 
-morpho_bystate[1] <- morpho
 for (i in 2:n_max_states) {
-    morpho_bystate[i] <- morpho                                # make local tmp copy of data
-    morpho_bystate[i].setNumStatesPartition(i)                 # only keep character blocks with state space equal to size i
-    nc = morpho_bystate[i].nchar()                             # get number of characters per character size with i-sized states
+    morpho_bystate[i - 1] <- morpho                             # make local tmp copy of data
+    morpho_bystate[i - 1].setNumStatesPartition(i)              # only keep character blocks with state space equal to size i
+    nc = morpho_bystate[i - 1].nchar()                          # get number of characters per character size with i-sized states
     if (nc > 0) {
-      i
-      for (j in iter_vect) {
-          beta_scale.redraw()
-          
-          pi_prior := fnDiscretizeBeta(beta_scale, beta_scale, i)
-          
-          # reverse the pi_prior vector
-          for (k in 1:pi_prior.size()) {
-              upper = pi_prior.size()
-              ind = upper + 1 - k
-              rev_pi_prior[k] <- pi_prior[ind]
-          }
-          
-          # create i-by-i rate matrices from both the original and reversed pi_prior vectors
-          Q[idx][j] := fnF81(simplex(pi_prior))
-          Q[idx][j+1] := fnF81(simplex(rev_pi_prior))
-          
-          Q[idx][j]
-          print(" ")
-          Q[idx][j+1]
-          print(" ")
-      }
+        print("There are "+nc+" characters with "+i+" states.")
+        # Place a symmetric Dirichlet prior on the equilibrium state frequencies
+        pi_prior[idx] := rep(dir_alpha, i)
 
-      mat_prior[idx] <- rep(1, 2*n_cats)
-      matrix_probs[idx] ~ dnDirichlet(mat_prior[idx])
+        for (j in 1:n_cats) {
+            # Draw a vector of equilibrium state frequencies from the specified prior
+            pi[idx][j] ~ dnDirichlet(pi_prior[idx])
+            moves.append( mvSimplexElementScale(pi[idx][j], alpha=10, weight=1.0) )
 
-      moves.append( mvBetaSimplex(matrix_probs[idx], weight=3.0) )
-      moves.append( mvDirichletSimplex(matrix_probs[idx], weight=1.5) )
+            # Reverse the pi[idx][j] vector
 
-      m_morph[idx] ~ dnPhyloCTMC(tree=phylogeny, siteRates=rates_morpho, Q=Q[idx],
-                                 type="Standard", siteMatrices=matrix_probs[idx])
-      m_morph[idx].clamp(morpho_bystate[i])
+            upper = pi[idx][j].size()
+            for (k in 1:upper) {
+                ind = upper + 1 - k
+                rev_pi[idx][j][k] <- pi[idx][j][ind]
+            }
+            
+            # Create i-by-i rate matrices from both the original and reversed state
+            # frequency vectors.
 
-      idx = idx + 1                                            # increment counter
-      idx
+            Q[idx][2*j - 1] := fnF81(pi[idx][j])
+            # Need to apply simplex() to convert rev_pi[idx][j] from type Probability[]
+            Q[idx][2*j] := fnF81(simplex(rev_pi[idx][j]))
+        }
+
+        print("The mixture contains "+Q[idx].size()+" rate matrices:")
+        for (l in 1:Q[idx].size()) {
+            print(" ")
+            Q[idx][l]
+        }
+        
+        # Tell the model what the probability of a character going into any particular
+        # category of the rate matrix mixture. The flat Dirichlet prior used here says
+        # that a character is equally likely to be put into any category.
+
+        mat_prior[idx] <- rep(1, 2*n_cats)
+        matrix_probs[idx] ~ dnDirichlet(mat_prior[idx])
+        
+        # Place move on the category assignment probabilities
+        moves.append( mvBetaSimplex(matrix_probs[idx], weight=3.0) )
+        moves.append( mvDirichletSimplex(matrix_probs[idx], weight=1.5) )
+        
+        # Combine all of our elements into a CTMC. Because we have not observed any
+        # invariant sites, we specify the coding as 'variable'. Note that we are now
+        # feeding the site matrices to the CTMC.
+
+        m_morph[idx] ~ dnPhyloCTMC(tree=phylogeny, siteRates=rates_morpho, Q=Q[idx],
+                                   type="Standard", siteMatrices=matrix_probs[idx])
+        # Clamp to the data
+        m_morph[idx].clamp(morpho_bystate[i - 1])
+
+        idx = idx + 1                                            # increment counter
     }
 }


### PR DESCRIPTION
This branch fixes the `mkv_model_gamma_discretized_multistate.Rev` script included with the Discrete Morphology tutorial. The script contains an implementation of the Site-Heterogeneous Discrete Morphology (SHDM) model, which extends [Wright et al.'s (2016)](https://academic.oup.com/sysbio/article/65/4/602/1753365) beta prior approach to relaxing the assumption of equal state frequencies to multistate characters. The previous implementation contained several bugs, which are now fixed here:

- The script attempted to make `pi` and `rev_pi` into local variables, which are not allowed in RevBayes (cf. [PR #251](https://github.com/revbayes/revbayes/pull/251)). As a result, these were overwritten with the value that was assigned to them in the last iteration of the loop.
- To generate several mutually different vectors of equilibrium state frequencies, the original script simply redrew the free parameter of the beta distribution (`beta_scale`) from the prior at every step, and deterministically derived the vector from each of the drawn values. This made little sense given that it also attempted to estimate `beta_scale` from the data. Here, the state frequency vectors are instead randomly drawn from a Dirichlet distribution, whose concentration parameter can in turn be meaningfully estimated.