### PR TITLE
Remove dn log exponential

### DIFF
--- a/tutorials/ted_workflow/files/data/taxa.tsv
+++ b/tutorials/ted_workflow/files/data/taxa.tsv
@@ -1,4 +1,4 @@
-taxon	min	max
+taxon	min_age	max_age
 Angiopteris_evecta	0	0
 Angiopteris_boninensis	0	0
 Botryopteris_tridentata	307	315.2

--- a/tutorials/ted_workflow/files/modules/mole_clock_models/UCE.Rev
+++ b/tutorials/ted_workflow/files/modules/mole_clock_models/UCE.Rev
@@ -12,12 +12,9 @@ mole_clock_rate_mean := exp(mole_clock_rate_mean_log)
 # the branch-specific rates
 for(i in 1:nbranch) {
 
-  # draw the log of the rate
-  mole_branch_rates_log[i] ~ dnLogExponential(1 / mole_clock_rate_mean)
-  moves.append( mvSlide(mole_branch_rates_log[i]) )
-
-  # exponentiate to get the rate
-  mole_branch_rates[i] := exp(mole_branch_rates_log[i])
+  # draw the rate
+  mole_branch_rates[i] ~ dnExponential(1 / mole_clock_rate_mean)
+  moves.append( mvScale(mole_branch_rates[i]) )
 
 }
 
@@ -25,4 +22,4 @@ for(i in 1:nbranch) {
 mole_branch_rate_mean := mean(mole_branch_rates)
 
 # add a joint move on the branch rates and standard deviation
-moves.append( mvVectorSlideRecenter(mole_branch_rates_log, mole_clock_rate_mean_log) )
+moves.append( mvVectorScale(mole_branch_rates, mole_clock_rate_mean) )

--- a/tutorials/ted_workflow/sections/mcmc.md
+++ b/tutorials/ted_workflow/sections/mcmc.md
@@ -259,12 +259,9 @@ mole_clock_rate_mean := exp(mole_clock_rate_mean_log)
 # the branch-specific rates
 for(i in 1:nbranch) {
 
-  # draw the log of the rate
-  mole_branch_rates_log[i] ~ dnLogExponential(1 / mole_clock_rate_mean)
-  moves.append( mvSlide(mole_branch_rates_log[i]) )
-
-  # exponentiate to get the rate
-  mole_branch_rates[i] := exp(mole_branch_rates_log[i])
+  # draw the rate
+  mole_branch_rates[i] ~ dnExponential(1 / mole_clock_rate_mean)
+  moves.append( mvScale(mole_branch_rates[i]) )
 
 }
 
@@ -272,7 +269,7 @@ for(i in 1:nbranch) {
 mole_branch_rate_mean := mean(mole_branch_rates)
 
 # add a joint move on the branch rates and hyperparameters
-moves.append( mvVectorSlideRecenter(mole_branch_rates_log, mole_clock_rate_mean_log) )
+moves.append( mvVectorScale(mole_branch_rates, mole_clock_rate_mean) )
 ```
 
 {% endaside %}


### PR DESCRIPTION
This PR removes dnLogExponential from the UCE model of @mikeryanmay's total-evidence tutorial.  To do that, I've switch the UCE model from using mvSlide on the log scale, to using mvScale on the untransformed scale.


