### PR TITLE
Remove FBDRP/FBDSP tutorials and all references to them

### DIFF
--- a/tutorials/dating/nodedate.md
+++ b/tutorials/dating/nodedate.md
@@ -27,7 +27,7 @@ In this exercise we will use information from the fossil record to calibrate the
 The molecular data used in this exercise is the same as the previous exercise (**bears_cytb.nex**). We will also use the same substitution and clock models (the GTR + $\Gamma$ model and the uncorrelated exponential clock model).
 
 We will also use the same tree model (the constant rate birth-death process), however, we will add calibration information from the fossil record to generate timetrees on a non-arbitrary timescale.
-The file **bears_taxa.tsv** contains information about the stratigraphic ranges for 20 bear species, including 12 extinct species. We're not going to use all of the information from this file in this exercise, because the node dating approach to calibration limits the amount of data we can take advantage of, but we'll use some of this information to constrain the age of two nodes. In this file `max` is the age of the first appearance (i.e. the oldest) of each species and `min` is the age of the last appearance (i.e. the youngest) (t = 0.0 represents the present). 
+The file **bears_taxa.tsv** contains information about the age ranges for 20 bear species, including 12 extinct species. We're not going to use all of the information from this file in this exercise, because the node dating approach to calibration limits the amount of data we can take advantage of, but we'll use some of this information to constrain the age of two nodes. In this file `max` is the age of the first appearance (i.e. the oldest) of each species and `min` is the age of the last appearance (i.e. the youngest) (t = 0.0 represents the present). 
 
 Again, there are just three steps you need to complete before running the analysis in this exercise. First, we need to create a script for the tree model and add our calibration information.
 Second, we need to switch out the tree model in our master script and update the name of the output files, so we don't overwrite the output generated in the previous exercise.
@@ -173,15 +173,10 @@ The FigTree window. To open your tree you can use File > Open. Select Node Label
 
 If you wanted to visualise the impact of the internal node calibrations, without the influence of the sequence data, you could run the MCMC analysis under the posterior and use an empty sequence alignment (this would be equivalent to running the analysis under the prior in BEAST and MCMCTree).
 
-### Next
+### Caveat
 
 Note that there are many more fossil species in the file **bears_taxa.tsv** with associated age information that we didn't use in this exercise.
 This is because, in the context of node dating, the calibration information is redundant with information already utilised (e.g. all other Urisinae species are younger than the fossil we used to constrain the age of this clade) or because we don't have good prior knowledge about the phylogenetic position of the species.
-
->Click below to begin the next exercise!
-{:.instruction}
-
-* [Estimating speciation times using the fossilized birth-death range model]({{ base.url }}/tutorials/dating/fbdr)
 
 <!--
 For further options and information about the models used in this exercise see Tracy Heath & Sebastian Höhna's tutorial [Divergence Time Calibration](https://github.com/revbayes/revbayes_tutorial/blob/master/tutorial_TeX/RB_DivergenceTime_Calibration_Tutorial/).

--- a/tutorials/fbd/fbd_specimen.md
+++ b/tutorials/fbd/fbd_specimen.md
@@ -38,7 +38,7 @@ probabilistic graphical model {% cite Hoehna2014b %} integrating three separate
 likelihood components or data partitions ({% ref fig_module_gm %}): one
 for molecular data ({% ref Intro-GTR %}), one for
 morphological data ({% ref Intro-Morpho %}), and one for
-fossil stratigraphic range data ({% ref Intro-FBD %}).
+fossil age data ({% ref Intro-FBD %}).
 In addition, all likelihood components are conditioned on a tree
 topology with divergence times which is modeled according to a separate
 prior component ({% ref Intro-TipSampling %}).
@@ -164,16 +164,20 @@ present.
 
 In order to account for uncertainty in the ages of our fossil species,
 we can incorporate intervals on the ages of our represented fossil
-species. These intervals can be stratigraphic ranges or measurement
-standard error. We do this by assuming each fossil can occur with
-uniform probability anywhere within its observed interval. This is
-somewhat different from the typical approach to node calibration. Here,
-instead of treating the calibration density as an additional prior
-distribution on the tree, we treat it as the *likelihood* of our fossil
-data given the tree parameter. Specifically, we assume the likelihood of
-a particular fossil's observed stratigraphic range $F_i = (a_i, b_i)$ is equal to one if the
-fossil’s inferred age on the tree $t_i$ falls within its observed time
-interval, and zero otherwise:
+tips. These should ideally represent specimen-level uncertainties
+(stemming from the imprecise dating of the geological unit from which
+a given fossil was collected) rather than stratigraphic ranges (i.e.,
+the interval between the first occurrence of a given species and its last
+occurrence, assuming that at least two stratigraphically unique occurrences
+do in fact exist). We can account for such specimen-level uncertainties
+by assuming each fossil can occur with uniform probability anywhere within
+its observed interval. This is somewhat different from the typical approach
+to node calibration. Here, instead of treating the calibration density as
+an additional prior distribution on the tree, we treat it as the *likelihood*
+of our fossil data given the tree parameter. Specifically, we assume the
+likelihood of a particular fossil's age uncertainty range $F_i = (a_i, b_i)$
+is equal to one if the fossil's inferred age on the tree $t_i$ falls within
+this interval, and zero otherwise:
 
 $$f[F_i \mid t_i] = \begin{cases}
 1 & \text{if } a_i < t_i < b_i\\
@@ -181,12 +185,12 @@ $$f[F_i \mid t_i] = \begin{cases}
 \end{cases}$$
 
 In other words, we assume the likelihood is equal to one
-if the inferred age is consistent with the observed data. We can
+if the inferred age is consistent with the age data. We can
 represent this likelihood in RevBayes using a distribution that is
 proportional to the likelihood,
 *i.e.* non-zero when the likelihood is equal
 to one ({% ref fig_tipsampling_gm %}). This model component represents
-the observed in the modular graphical model shown in {% ref fig_module_gm %}.
+the "Fossil Occurrence Time Data" in the modular graphical model shown in {% ref fig_module_gm %}.
 
 {% figure fig_tipsampling_gm %}
 <img src="figures/tikz/tipsampling_gm.png" width="400" /> 
@@ -194,22 +198,17 @@ the observed in the modular graphical model shown in {% ref fig_module_gm %}.
 A graphical model of the
 fossil age likelihood model used in this tutorial. The likelihood of
 fossil observation $\mathcal{F}_i$ is uniform and non-zero when the
-inferred fossil age $t_i$ falls within the observed time interval
+inferred fossil age $t_i$ falls within the age uncertainty interval
 $(a_i,b_i)$.
 {% endfigcaption %}
 {% endfigure %}
 
-It is worth noting that this is not necessarily the appropriate way to
-model fossil data that are actually observed as stratigraphic ranges. In
-paleontology, a stratigraphic range represents the interval of time
-between the first and last appearances of a fossilized species. Thus,
-this range typically represents multiple fossil specimens observed at
-different times along a single lineage. An extension of the fossilized
-birth-death process that is a distribution on stratigraphic ranges has
-been described by {% citet Stadler2018 %}. 
-This model is fully implemented in RevBayes as the "fossilized birth-death *range* process". 
-For a detailed description of analysis under this model, please see the tutorial on {% page_ref fbd %}.
-
+Once again, it is worth noting that this is not the appropriate way to
+model fossil data that consist of stratigraphic ranges, which represent
+multiple fossil specimens (each of which can further be associated with
+its own specimen-level uncertainty) observed at different times along a
+single lineage. An extension of the fossilized birth-death process that
+is a distribution on stratigraphic ranges was described by {% citet Stadler2018 %}. 
 
 
 {% include_relative sections/sec-Intro-GTR.md %}

--- a/tutorials/fbd/index.md
+++ b/tutorials/fbd/index.md
@@ -10,7 +10,7 @@ prerequisites:
 exclude_files:
 - mcmc_CEFBDP_Specimens.Rev
 - model_FBDP.Rev
-index: true
+index: false
 title-old: RB_TotalEvidenceDating_FBD_Tutorial
 redirect: false
 ---

--- a/tutorials/fbd_range/index.md
+++ b/tutorials/fbd_range/index.md
@@ -6,7 +6,7 @@ level: 7
 order: 10
 prerequisites:
 - fbd
-index: true
+index: false
 ---
 
 {% section Overview %}

--- a/tutorials/fbd_simple/index.md
+++ b/tutorials/fbd_simple/index.md
@@ -79,7 +79,7 @@ However, if certain taxa persist through time and
 fossilize particularly well, then the same taxon may be sampled at different stratigraphic ages. 
 These fossil data are commonly represented by only 
 the first and last appearances of a fossil morphospecies. 
-In this case one might want to consider the [fossilized birth-death range process]({% page_url fbd_range %}) {% cite Stadler2018 %} in RevBayes to model the stratigraphic ranges of fossil occurrences.
+In this case one might want to consider the fossilized birth-death range process {% cite Stadler2018 %} to model the stratigraphic ranges of fossil occurrences.
 
 
 {% subsubsection Accounting for Fossil Age Uncertainty | Intro-Foss-Samp %}
@@ -363,7 +363,7 @@ Such complex variables require more extensive sampling than other nodes.
 We need to account for uncertainty in the age estimates of our fossils using the observed 
 minimum and maximum stratigraphic ages that are provided in the file `bears_taxa.tsv`.
 We can represent the fossil likelihood using any uniform distribution that is non-zero when the likelihood is equal to one (see {% ref Intro-Foss-Samp %}).
-For example, if $t_i$ is the inferred fossil age and $(a_i,b_i)$ is the observed stratigraphic interval, we know the likelihood is equal to one when $a_i < t_i < b_i$, or equivalently $t_i - b_i < 0 < t_i - a_i$.
+For example, if $t_i$ is the inferred fossil age and $(a_i,b_i)$ is the stratigraphic age uncertainty interval, we know the likelihood is equal to one when $a_i < t_i < b_i$, or equivalently $t_i - b_i < 0 < t_i - a_i$.
 So we can represent this likelihood using a uniform random variable,  uniformly distributed in $(t_i - b_i, t_i - a_i)$ and clamped at zero.
 
 To do this, we will get all the fossils from the tree and use a `for` loop to iterate over them. For each fossil observation, we will create a uniform random variable 


### PR DESCRIPTION
Unfortunately, we currently [cannot guarantee](https://github.com/revbayes/revbayes/issues/451) that our implementation of the FBD-range process with (`dnFBDSP`) or without (`dnFBDRP`) tree inference yields correct likelihoods – in fact, we are quite sure that the former doesn't, and while the latter may well be correct or only require minor fixes, it hasn't been thoroughly validated. Therefore, this PR:

- Removes the two tutorials we currently have on this topic ("Combined-Evidence Analysis and the Fossilized Birth-Death Process for Stratigraphic Range Data" and "Macroevolutionary Analysis of Stratigraphic Range Data" for the tree-inference and tree-free versions, respectively). Note that a third tutorial employing `dnFBDRP` ("Estimating speciation times using the fossilized birth-death range process") is already unindexed.

- Removes the references to these tutorials, or any statements suggesting that the FBD-range process is implemented in RevBayes, from the remaining tutorials. Of these, one is indexed ("Combined-Evidence Analysis and the Fossilized Birth-Death Process for Analysis of Extant Taxa and Fossil Specimens") and two are unindexed ("Estimating a Time-Calibrated Phylogeny of Fossil and Extant Taxa using Morphological Data" and "Estimating speciation times using node dating").

- Changes some wording in "Combined-Evidence Analysis and the Fossilized Birth-Death Process for Analysis of Extant Taxa and Fossil Specimens" to make it a bit clearer when to use specimen-level FBD and when to use FBD-range. The current version basically says "your age range can represent uncertainty or a stratigraphic range", and then proceeds to explain two paragraphs later why using stratigraphic ranges is actually a bad idea. I thought it better to make this clear from the beginning.