### PR TITLE
removeExcludedCharacters()

### DIFF
--- a/tutorials/morph_tree/V2.md
+++ b/tutorials/morph_tree/V2.md
@@ -201,6 +201,7 @@ morpho_bystate[1] <- morpho
 for (i in 2:n_max_states) {
     morpho_bystate[i] <- morpho                                # make local tmp copy of data
     morpho_bystate[i].setNumStatesPartition(i)                 # only keep character blocks with state space equal to size i
+    morpho_bystate[i].removeExcludedCharacters()               # remove unused characters from memory
     nc = morpho_bystate[i].nchar()                             # get number of characters per character size with i-sized states
 
     if (nc > 0) {                                              # for non-empty character blocks


### PR DESCRIPTION
I've added `morpho_bystate[i].removeExcludedCharacters()` per https://github.com/revbayes/revbayes/issues/552.

Whilst I'm here, I find `V2` a non-intuitive name for this page; I think it's intended as a follow-on from https://revbayes.github.io/tutorials/morph_tree/ that expands to include the case of multi-state characters, rather than an updated replacement to "V1".  Is there a case for renaming the file something like "multistate.md", and for referencing/linking to each file from the other?