### PR TITLE
Tutorial cleanup

### DIFF
--- a/tutorials/dating/index.md
+++ b/tutorials/dating/index.md
@@ -24,7 +24,7 @@ This tutorial aims to guide you through different options for calibrating specie
 
 In [exercises 1]({{ base.url }}/tutorials/dating/global) and [2]({{ base.url }}/tutorials/dating/relaxed) we'll use the molecular sequence data to infer the relationships among living species and transform the branch lengths assuming a strict or relaxed clock model. Since these analyses don't incorporate any information from the geological record, this approach can only be used to infer the *relative* age of speciation events. 
 
-In [exercises 3]({{ base.url }}/tutorials/dating/nodedate) and [4]({{ base.url }}/tutorials/dating/fbdr) we'll use information from the fossil record to calibrate the tree to *absolute* time using two different approaches to calibration (node dating versus the fossilized birth-death process). Finally, in [exercise 5]({{ base.url }}/tutorials/dating/tefbd) we'll also incorporate the morphological data to infer the relationships and divergence times among living and fossil bear species (total-evidence dating).
+In [exercise 3]({{ base.url }}/tutorials/dating/nodedate) we'll use information from the fossil record to calibrate the tree to *absolute* time using node-dating. Finally, in [exercise 4]({{ base.url }}/tutorials/fbd/fbd_specimen) we'll also incorporate the morphological data to infer the relationships and divergence times among living and fossil bear species (total-evidence dating).
 
 ### The data
 
@@ -61,4 +61,4 @@ In this tutorial, you will work primarily in your text editor and create a set o
 1. [The global molecular clock model]({{ base.url }}/tutorials/dating/global)
 2. [The uncorrelated exponential relaxed clock model]({{ base.url }}/tutorials/dating/relaxed)
 3. [Estimating speciation times using node dating]({{ base.url }}/tutorials/dating/nodedate)
-4. [Estimating speciation times using the fossilized birth-death process]({{ base.url }}/tutorials/dating/fbd_simple)
+4. [Estimating speciation times using the fossilized birth-death process]({{ base.url }}/tutorials/fbd/fbd_specimen)

--- a/tutorials/dating/index.md
+++ b/tutorials/dating/index.md
@@ -20,7 +20,7 @@ This tutorial aims to guide you through different options for calibrating specie
 
 * [Relaxed Clocks & Time Trees]({{ base.url }}/tutorials/clocks/) written by Tracy Heath
 * [Divergence Time Calibration](https://github.com/revbayes/revbayes_tutorial/blob/master/tutorial_TeX/RB_DivergenceTime_Calibration_Tutorial/) written by Tracy Heath and Sebastian Höhna
-* [Combined-Evidence Analysis and the Fossilized Birth-Death Process for Stratigraphic Range Data]({{ base.url }}/tutorials/fbd/) written by Tracy Heath, April Wright and Walker Pett
+* [Estimating a Time-Calibrated Phylogeny of Fossil and Extant Taxa using Morphological Data]({{ base.url }}/tutorials/fbd_simple/) written by Joëlle Barido-Sottani, Joshua Justison, April M. Wright, Rachel C. M. Warnock, Walker Pett, and Tracy A. Heath
 
 In [exercises 1]({{ base.url }}/tutorials/dating/global) and [2]({{ base.url }}/tutorials/dating/relaxed) we'll use the molecular sequence data to infer the relationships among living species and transform the branch lengths assuming a strict or relaxed clock model. Since these analyses don't incorporate any information from the geological record, this approach can only be used to infer the *relative* age of speciation events. 
 
@@ -61,5 +61,4 @@ In this tutorial, you will work primarily in your text editor and create a set o
 1. [The global molecular clock model]({{ base.url }}/tutorials/dating/global)
 2. [The uncorrelated exponential relaxed clock model]({{ base.url }}/tutorials/dating/relaxed)
 3. [Estimating speciation times using node dating]({{ base.url }}/tutorials/dating/nodedate)
-4. [Estimating speciation times using the fossilized birth-death range process]({{ base.url }}/tutorials/dating/fbdr)
-5. [Estimating speciation times using total-evidence dating]({{ base.url }}/tutorials/dating/tefbd)
+4. [Estimating speciation times using the fossilized birth-death process]({{ base.url }}/tutorials/dating/fbd_simple)

--- a/tutorials/fbd_simple/index.md
+++ b/tutorials/fbd_simple/index.md
@@ -709,7 +709,6 @@ paleontological and neontological data in RevBayes.
 For more information on how to apply RevBayes
 datasets combining morphological and molecular
 characters, please refer to the 
-following tutorials:
+following tutorial:
 
-1. {% page_ref fbd/fbd_specimen %}
-2. {% page_ref fbd %}
+- {% page_ref fbd/fbd_specimen %}

--- a/tutorials/pomos/index.md
+++ b/tutorials/pomos/index.md
@@ -8,7 +8,7 @@ prerequisites:
 - intro
 - mcmc
 - ctmc
-index: true
+index: false
 title-old:
 redirect: false
 ---


### PR DESCRIPTION
This PR:

- Attempts to rid all indexed dating tutorials of references to the (currently un-indexed) FBD-range tutorials. However, the dating tutorials in general are one big mess with multiple near-duplicates (compare, e.g., the `fbd_specimen` tutorial that lives in the `fbd` folder with the one from the `fbd_simple` folder), and a more thorough cleanup is in order...
- Temporarily un-indexes the polymorphism-aware model (PoMo) tutorial, which currently can't be run. I think the original intention was for it to run on the `dev_PoMo_SNP` branch, which is already a bit problematic (many users would probably rightly expect all tutorials to work with the latest stable release), but even that's not the case.