### PR TITLE
update before `libboost-all-dev`

### DIFF
--- a/home/compile_linux.md
+++ b/home/compile_linux.md
@@ -22,7 +22,8 @@ Install these using your distribution's package manager
 
 #### Ubuntu
 
-    sudo apt install build-essential cmake libboost-dev
+    sudo apt update
+    sudo apt install build-essential cmake libboost-all-dev
 
 #### CentOS 8
 

--- a/home/compile_linux.md
+++ b/home/compile_linux.md
@@ -22,7 +22,7 @@ Install these using your distribution's package manager
 
 #### Ubuntu
 
-    sudo apt install build-essential cmake libboost-all-dev
+    sudo apt install build-essential cmake libboost-dev
 
 #### CentOS 8
 


### PR DESCRIPTION
I got in a tangle building from source on a new ubuntu build.

It is necessary to run `apt update` before `apt install libboost-all-dev`, which is otherwise not found.  Probably goes without saying to an experienced linux user, but perhaps worth including for novices like me?