### PR TITLE
Replace calls to `.makeBifurcating()` in the stepwise inference tutorial

### DIFF
--- a/tutorials/sequential_bayes/scripts/mcmc_ultrametric.Rev
+++ b/tutorials/sequential_bayes/scripts/mcmc_ultrametric.Rev
@@ -91,7 +91,13 @@ time_tree ~ dnBirthDeath(rootAge=root_time, lambda=birth_rate, mu=death_rate, ta
 ## initialize the time tree with the MAP tree from our previous analysis
 ## you could also use an externally rooted tree
 unrooted_MAP_tree = readBranchLengthTrees("output/photinus_"+GENE+"_MAP.tre")[1]
-unrooted_MAP_tree.makeBifurcating()
+
+## resolve the trifurcation at the root
+root_index = 2*unrooted_MAP_tree.ntips() - 2
+first_child = unrooted_MAP_tree.getDescendantTaxa( unrooted_MAP_tree.child( root_index, 1 ) )
+unrooted_MAP_tree.reroot( clade(first_child), makeBifurcating=TRUE)
+
+## make the tree ultrametric and restore node indices
 ultrametric_MAP_tree = unrooted_MAP_tree.makeUltrametric()
 ultrametric_MAP_tree.rescale( root_time / ultrametric_MAP_tree.rootAge() )
 time_tree.setValue( ultrametric_MAP_tree )

--- a/tutorials/sequential_bayes/stepwise_dating.md
+++ b/tutorials/sequential_bayes/stepwise_dating.md
@@ -126,14 +126,20 @@ In this analysis, it might be very important to initialize the time tree with a 
 Remember that the probability of the tree topology will be computed by the sample frequency {% cite Hoehna2024 %}, thus all topologies that were not sampled in the previous analysis have a probability of 0.
 Such trees are problematic as we cannot initialize the MCMC with them, as computing the acceptance ratio entails a division by 0.
 
-Henve, we initialize the time tree with the MAP tree from our previous analysis.
+Hence, we initialize the time tree with the MAP tree from our previous analysis.
 You could also use an externally rooted tree, which might be preferred.
 ```
 unrooted_MAP_tree = readBranchLengthTrees("output/photinus_COI_MAP.tre")[1]
 ```
-Now we need to make this tree bifurcating (the root was trifurcating) and to make it ultrametric.
+Since the tree comes from a non-clock analysis, it is unrooted, which is to say it has a trifurcation at the root.
+We want to make its root bifurcating, but it is not important to us exactly how we do it. Therefore, we will just grab the first of the three children of the root node and make it the outgroup:
 ```
-unrooted_MAP_tree.makeBifurcating()
+root_index = 2*unrooted_MAP_tree.ntips() - 2
+first_child = unrooted_MAP_tree.getDescendantTaxa( unrooted_MAP_tree.child( root_index, 1 ) )
+unrooted_MAP_tree.reroot( clade(first_child), makeBifurcating=TRUE)
+```
+We also need to make the tree ultrametric:
+```
 ultrametric_MAP_tree = unrooted_MAP_tree.makeUltrametric()
 ultrametric_MAP_tree.rescale( root_time / ultrametric_MAP_tree.rootAge() )
 ```


### PR DESCRIPTION
This PR makes a small change to the [stepwise dating tutorial](https://revbayes.github.io/tutorials/sequential_bayes/stepwise_dating) following the changes to the `.makeBifurcating()` method of class `Tree` (PR [#618](https://github.com/revbayes/revbayes/pull/618)). The new solution is quite long-winded; I hope to replace it again by `.resolveMultifurcations()` once the relevant branch has been merged. 

The bigger problem is that the tutorial doesn't seem to work. Not as a result of my change; I already couldn't get it to work with `.makeBifurcating()` still in there, using a branch of RevBayes that contained the method.