### PR TITLE
Restructuring tutorial tests

### DIFF
--- a/tutorials/ctmc/scripts/mcmc_GTR.Rev
+++ b/tutorials/ctmc/scripts/mcmc_GTR.Rev
@@ -28,15 +28,15 @@ monitors = VectorMonitors()
 # specify the stationary frequency parameters
 pi_prior <- v(1,1,1,1) 
 pi ~ dnDirichlet(pi_prior)
-moves.append( mvBetaSimplex(pi, weight=2.0) )
-moves.append( mvDirichletSimplex(pi, weight=1.0) )
+moves.append( mvBetaSimplex(pi, weight=2) )
+moves.append( mvDirichletSimplex(pi, weight=1) )
 
 
 # specify the exchangeability rate parameters
 er_prior <- v(1,1,1,1,1,1)
 er ~ dnDirichlet(er_prior)
-moves.append( mvBetaSimplex(er, weight=3.0) )
-moves.append( mvDirichletSimplex(er, weight=1.5) )
+moves.append( mvBetaSimplex(er, weight=3) )
+moves.append( mvDirichletSimplex(er, weight=1) )
 
 
 # create a deterministic variable for the rate matrix, GTR
@@ -85,13 +85,13 @@ seq.clamp(data)
 mymodel = model(psi)
 
 # add monitors
-monitors.append( mnScreen(TL, printgen=100) )
-monitors.append( mnFile(psi, filename="output/primates_cytb_GTR.trees", printgen=10) )
+monitors.append( mnScreen(printgen=100, TL) )
+monitors.append( mnFile(filename="output/primates_cytb_GTR.trees", printgen=10, psi) )
 monitors.append( mnModel(filename="output/primates_cytb_GTR.log", printgen=10) )
 
 # run the analysis
 mymcmc = mcmc(mymodel, moves, monitors)
-mymcmc.run(generations=10000)
+mymcmc.run(generations=20000)
 
 
 # summarize output

--- a/tutorials/ctmc/scripts/mcmc_GTR_Gamma_Inv.Rev
+++ b/tutorials/ctmc/scripts/mcmc_GTR_Gamma_Inv.Rev
@@ -28,15 +28,15 @@ monitors = VectorMonitors()
 # specify the stationary frequency parameters
 pi_prior <- v(1,1,1,1) 
 pi ~ dnDirichlet(pi_prior)
-moves.append( mvBetaSimplex(pi, weight=2.0) )
-moves.append( mvDirichletSimplex(pi, weight=1.0) )
+moves.append( mvBetaSimplex(pi, weight=2) )
+moves.append( mvDirichletSimplex(pi, weight=1) )
 
 
 # specify the exchangeability rate parameters
 er_prior <- v(1,1,1,1,1,1)
 er ~ dnDirichlet(er_prior)
-moves.append( mvBetaSimplex(er, weight=3.0) )
-moves.append( mvDirichletSimplex(er, weight=1.5) )
+moves.append( mvBetaSimplex(er, weight=3) )
+moves.append( mvDirichletSimplex(er, weight=1) )
 
 
 # create a deterministic variable for the rate matrix, GTR
@@ -48,15 +48,14 @@ Q := fnGTR(er,pi)
 #############################
 
 # among site rate variation, +Gamma4
-alpha ~ dnUniform( 0, 10 )
-sr := fnDiscretizeGamma( alpha, alpha, 4, false )
+alpha ~ dnUniform( 0.0, 10 )
+sr := fnDiscretizeGamma( alpha, alpha, 4 )
 moves.append( mvScale(alpha, weight=2.0) )
 
 
 # the probability of a site being invariable, +I
 p_inv ~ dnBeta(1,1)
-moves.append( mvBetaProbability(p_inv, weight=2.0) )
-
+moves.append( mvSlide(p_inv) )
 
 ##############
 # Tree model #
@@ -99,13 +98,13 @@ seq.clamp(data)
 mymodel = model(psi)
 
 # add monitors
-monitors.append( mnScreen(alpha, p_inv, TL, printgen=100) )
-monitors.append( mnFile(psi, filename="output/primates_cytb_GTRGI.trees", printgen=10) )
+monitors.append( mnScreen(printgen=100, alpha, p_inv, TL) )
+monitors.append( mnFile(filename="output/primates_cytb_GTRGI.trees", printgen=10, psi) )
 monitors.append( mnModel(filename="output/primates_cytb_GTRGI.log", printgen=10) )
 
 # run the analysis
 mymcmc = mcmc(mymodel, moves, monitors)
-mymcmc.run(generations=10000)
+mymcmc.run(generations=20000)
 
 
 # summarize output

--- a/tutorials/ctmc/scripts/mcmc_HKY.Rev
+++ b/tutorials/ctmc/scripts/mcmc_HKY.Rev
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# RevBayes Example: Bayesian inference of phylogeny using a Jukes-Cantor
+# RevBayes Example: Bayesian inference of phylogeny using a Hasegawa-Kishino-Yano 
 #            substitution model on a single gene.
 #
 # authors: Sebastian Hoehna, Michael Landis, and Tracy A. Heath
@@ -24,9 +24,22 @@ monitors = VectorMonitors()
 # Substitution Model #
 ######################
 
-# create a constant variable for the rate matrix
-Q <- fnJC(4)
+# prior for the stationary frequencies
+pi_prior <- v(1,1,1,1)
+pi ~ dnDirichlet(pi_prior)
 
+# add moves to pi
+moves.append( mvBetaSimplex(pi, weight=2) )
+moves.append( mvDirichletSimplex(pi, weight=1) )
+
+# prior for the transition-transversions rate
+kappa ~ dnLognormal(0.0, 1.0)
+
+# add moves to kappa
+moves.append( mvScale(kappa) )
+
+# create a variable for the HKY rate matrix
+Q := fnHKY(kappa,pi)
 
 ##############
 # Tree model #
@@ -69,8 +82,8 @@ mymodel = model(Q)
 
 # add monitors
 monitors.append( mnScreen(printgen=100, TL) )
-monitors.append( mnFile(filename="output/primates_cytb_JC.trees", printgen=10, psi) )
-monitors.append( mnModel(filename="output/primates_cytb_JC.log", printgen=10) )
+monitors.append( mnFile(filename="output/primates_cytb_HKY.trees", printgen=10, psi) )
+monitors.append( mnModel(filename="output/primates_cytb_HKY.log", printgen=10) )
 
 # run the analysis
 mymcmc = mcmc(mymodel, moves, monitors)
@@ -83,9 +96,9 @@ mymcmc.run(generations=20000)
 
 # Now, we will analyze the tree output.
 # Let us start by reading in the tree trace
-treetrace = readTreeTrace("output/primates_cytb_JC.trees", treetype="non-clock")
+treetrace = readTreeTrace("output/primates_cytb_HKY.trees", treetype="non-clock")
 # and then get the MAP tree
-map_tree = mapTree(treetrace,"output/primates_cytb_JC_MAP.tree")
+map_tree = mapTree(treetrace,"output/primates_cytb_HKY_MAP.tree")
 
 
 # you may want to quit RevBayes now

--- a/tutorials/ctmc/test.sh
+++ b/tutorials/ctmc/test.sh
@@ -1,6 +1,0 @@
-sed -i.bak 's/generations=10000/generations=1/g' scripts/mcmc_GTR_Gamma_Inv.Rev
-${rb_exec} -b scripts/mcmc_GTR_Gamma_Inv.Rev
-res="$?"
-mv scripts/mcmc_GTR_Gamma_Inv.Rev.bak scripts/mcmc_GTR_Gamma_Inv.Rev
-rm -rf output
-exit $res

--- a/tutorials/ctmc/tests.txt
+++ b/tutorials/ctmc/tests.txt
@@ -1,0 +1,4 @@
+mcmc_GTR.Rev
+mcmc_GTR_Gamma_Inv.Rev
+mcmc_HKY.Rev
+mcmc_JC.Rev

--- a/tutorials/dating/global.md
+++ b/tutorials/dating/global.md
@@ -84,12 +84,12 @@ extinction_rate ~ dnExponential(10)
 ```
 For every stochastic node we declare, we must also specify moves (or proposal algorithms) to sample the value of the parameter in proportion to its posterior probability. If a move is not specified for a stochastic node, then it will not be estimated, but fixed to its initial value.
 
-The rate parameters for extinction and speciation are both positive, real numbers (i.e. non-negative floating point variables). For both of these nodes, we will use a scaling move (`mvScale`), which proposes multiplicative changes to a parameter. Many moves also require us to set a tuning value, called `lambda` for `mvScale`, which determine the size of the proposed change. Here, we will also use `tune=true`, which will alter the magnitude of the proposed changes after an intital tuning phase. Note there are many different strategies available in RevBayes for improving mixing and convergence. See the tutorial [Diagnosing MCMC performance]({{ base.url }}/tutorials for more information on this topic.
+The rate parameters for extinction and speciation are both positive, real numbers (i.e. non-negative floating point variables). For both of these nodes, we will use a scaling move (`mvScale`), which proposes multiplicative changes to a parameter. Many moves also require us to set a tuning value, called `lambda` for `mvScale`, which determine the size of the proposed change. Here, we will also use `tune=true`, which will alter the magnitude of the proposed changes after an intital tuning phase. Note there are many different strategies available in RevBayes for improving mixing and convergence. See the tutorial {% page_ref mcmc_troubleshooting %} for more information on this topic.
 ```
 moves.append( mvScale(speciation_rate, lambda=0.5, tune=true, weight=3.0) )
 moves.append( mvScale(extinction_rate, lambda=0.5, tune=true, weight=3.0) )
 ```
-The `weight` option allows you to indicate how many times you would like a given move to be performed at each MCMC cycle. In this tutorial we will run our MCMC for this tutorial will be to execute a *schedule* of moves at each step in our chain instead of just one move per step. Here, if we were to run our MCMC with our current vector of 6 moves, then our move schedule would perform 6 moves at each cycle. Within a cycle, an individual move is chosen from the move list in proportion to its weight. Therefore, with all six moves assigned `weight=1`, each has an equal probability of being executed and will be performed on average one time per MCMC cycle. For more information on moves and how they are performed in RevBayes, please refer to the {% page_ref mcmc %} and {% page_ref ctmc %} tutorials.
+The `weight` option allows you to indicate how many times you would like a given move to be performed at each MCMC cycle. In this tutorial we will execute a *schedule* of moves at each step in our chain instead of just one move per step. Here, if we were to run our MCMC with our current vector of 6 moves, then our move schedule would perform 6 moves at each cycle. Within a cycle, an individual move is chosen from the move list in proportion to its weight. Therefore, with all six moves assigned `weight=1`, each has an equal probability of being executed and will be performed on average one time per MCMC cycle. For more information on moves and how they are performed in RevBayes, please refer to the {% page_ref mcmc %} and {% page_ref ctmc %} tutorials.
 
 In addition to the speciation ($\lambda$) and extinction ($\mu$) rates, we may also be interested in inferring diversification ($\lambda - \mu$) and turnover ($\mu/\lambda$). Since these parameters can be expressed as a deterministic transformation of the speciation and extinction rates, we can monitor (that is, track the values of these parameters, and print them to a file) their values by creating two deterministic nodes using the `:=` operator.
 ```
@@ -149,7 +149,7 @@ We may be interested in monitoring the age of a given node in our MCMC sample. W
 ```
 age_ursinae := tmrca(timetree, clade_ursinae)
 ```
-Note that if we had not included this clade in the constraints that defined the `timetree` variable this node would not be constrained to be monophyletic but we could still monitor the age using the `tmrca` approach.
+Note that if we had not included this clade in the constraints that defined the `timetree` variable, this node would not be constrained to be monophyletic, but we could still monitor the age using the `tmrca` approach.
 
 
 
@@ -191,8 +191,8 @@ er ~ dnDirichlet(er_hp)
 ```
 We need special moves to propose changes to a Dirichlet random variable, also known as a simplex (a vector constrained to sum to one). Here, we use a `mvSimplexElementScale` move, which scales a single element of a simplex and then renormalises the vector to sum to one. The tuning parameter `alpha` specifies how conservative the proposal should be, with larger values of alpha leading to proposals closer to the current value.
 ```
-moves.append( mvSimplexBeta(er, alpha=10.0, weight=3.0) )
-moves.append( mvSimplexBeta(sf, alpha=10.0, weight=2.0) )
+moves.append( mvBetaSimplex(er, alpha=10.0, weight=3.0) )
+moves.append( mvBetaSimplex(sf, alpha=10.0, weight=2.0) )
 ```
 Then we can define a deterministic node for our GTR Q-matrix using the special GTR matrix function (`fnGTR`).
 ```
@@ -245,7 +245,7 @@ monitors.append( mnFile(filename="output/bears_global.trees", printgen=10, timet
 ```
 The last monitor we will add to our analysis will print information to the screen. As with `mnFile` we must tell `mnScreen` which parameters we’d like to see updated on the screen. We will choose the age of the MRCA of living bears (`extant_mrca`) and the diversification rate (`diversification`) parameters.
 ```
-monitors.append( mnScreen(printgen=10, extant_mrca, diversification, branch_rates) )
+monitors.append( mnScreen(printgen=10, extant_mrca, diversification) )
 ```
 Once we have set up our model, moves, and monitors, we can now create the workspace variable that defines our MCMC run. We do this using the `mcmc` function that simply takes the three main analysis components as arguments.
 ```
@@ -286,7 +286,7 @@ The Trace window in the program Tracer. Click on the "+" sign to load your trace
 {% endfigcaption %}
 {% endfigure %}
 
-Note that the speciation and extinction rates are not especially meaningful because we don't they're not in absolute time.
+Note that the speciation and extinction rates are not especially meaningful because they're not in absolute time.
 
 
 

--- a/tutorials/dating/nodedate.md
+++ b/tutorials/dating/nodedate.md
@@ -181,6 +181,13 @@ If you wanted to visualise the impact of the internal node calibrations, without
 Note that there are many more fossil species in the file **bears_taxa.tsv** with associated age information that we didn't use in this exercise.
 This is because, in the context of node dating, the calibration information is redundant with information already utilised (e.g. all other Urisinae species are younger than the fossil we used to constrain the age of this clade) or because we don't have good prior knowledge about the phylogenetic position of the species.
 
+### Next
+
+>Click below to begin the next exercise!
+{:.instruction}
+
+* [Estimating speciation times using the fossilized birth-death process]({{ base.url }}/tutorials/fbd/fbd_specimen)
+
 <!--
 For further options and information about the models used in this exercise see Tracy Heath & Sebastian Höhna's tutorial [Divergence Time Calibration](https://github.com/revbayes/revbayes_tutorial/blob/master/tutorial_TeX/RB_DivergenceTime_Calibration_Tutorial/).
 -->

--- a/tutorials/dating/relaxed.md
+++ b/tutorials/dating/relaxed.md
@@ -68,7 +68,7 @@ First, we will use a vector scale move to propose changes to all branch rates si
 This way we can sample the total branch rate independently of each individual rate, which can improve mixing.
 Second, we will use a move (`mvRateAgeBetaShift`) that changes the node ages and branch rates jointly,
 so that the effective branch length (the product of branch time and branch rate) remains the same.
-Thus, the move is proposing values with same the likelihood but a different prior probability.
+Thus, the move is proposing values with the same likelihood but a different prior probability.
 ```
 moves.append( mvVectorScale(branch_rates, lambda=0.5, tune=true, weight=4.0) )
 moves.append( mvRateAgeBetaShift(tree=timetree, rates=branch_rates, tune=true, weight=n_taxa) )

--- a/tutorials/dating/scripts/MCMC_dating_ex2b.Rev
+++ b/tutorials/dating/scripts/MCMC_dating_ex2b.Rev
@@ -2,17 +2,17 @@
 #
 # RevBayes Example: Molecular dating
 # 
-# This file: Runs the full MCMC for exercise 3
+# This file: Runs the full MCMC for exercise 2
 #
 # authors: Rachel C. M. Warnock, Sebastian Hoehna
 #
 ########################################################
 
-############################################################
+##################################################################
 #
-# Exercise 3: Estimating speciation times using node dating
+# Exercise 2: the The uncorrelated exponential relaxed clock model
 #
-############################################################
+##################################################################
 
 #######################
 # Reading in the Data #
@@ -33,9 +33,9 @@ monitors = VectorMonitors()
 
 # Load the model files
 
-source("scripts/tree_BD_nodedate.Rev") # BD tree prior + node calibrations
+source("scripts/tree_BD.Rev") # BD tree prior
 
-source("scripts/clock_relaxed_exponential.Rev") # Relaxed exponential clock model
+source("scripts/clock_relaxed_lognormal.Rev") # Relaxed exponential clock model
 
 source("scripts/sub_GTRG.Rev") # Molecular substitution model (GTR+G)
 
@@ -48,13 +48,13 @@ mymodel = model(sf)
 
 # Create a vector of monitors #
 # 1. for the full model #
-monitors.append( mnModel(filename="output/bears_nodedate.log", printgen=10)	)
+monitors.append( mnModel(filename="output/bears_relaxed_lognormal.log", printgen=10) )
 
 # 2. the tree #
-monitors.append( mnFile(filename="output/bears_nodedate.trees", printgen=10, timetree) )
+monitors.append( mnFile(filename="output/bears_relaxed_lognormal.trees", printgen=10, timetree) )
 
 # 3. and a few select parameters to be printed to the screen #
-monitors.append( mnScreen(printgen=10, extant_mrca, diversification) )
+monitors.append( mnScreen(printgen=100, extant_mrca, diversification) )
 
 # Initialize the MCMC object #
 mymcmc = mcmc(mymodel, monitors, moves, nruns=2, combine="mixed")
@@ -62,15 +62,16 @@ mymcmc = mcmc(mymodel, monitors, moves, nruns=2, combine="mixed")
 # Run the MCMC #
 mymcmc.run(generations=20000, tuningInterval=200)
 
+
 ########################
 # Summarizing the tree #
 ########################
 
 # Read the trace file #
-trace = readTreeTrace("output/bears_nodedate.trees")
+trace = readTreeTrace("output/bears_relaxed_lognormal.trees")
 
 # Maximum clade credibility tree #
-mccTree(trace, file="output/bears_nodedate.mcc.tre" )
+mccTree(trace, file="output/bears_relaxed_lognormal.mcc.tre" )
 
 # Quit RevBayes #
 q()

--- a/tutorials/dating/scripts/MCMC_dating_ex3_only_fossil_data.Rev
+++ b/tutorials/dating/scripts/MCMC_dating_ex3_only_fossil_data.Rev
@@ -46,14 +46,14 @@ source("scripts/sub_GTRG.Rev") # Molecular substitution model (GTR+G)
 # initialize the model object #
 mymodel = model(sf)	
 
+# ignore phySeq node to run with fossil data only
+mymodel.ignoreData(phySeq) 		# obs_age_ursinae is retained
+
 # Create a vector of monitors #
 # 1. for the full model #
-monitors.append( mnModel(filename="output/bears_nodedate.log", printgen=10)	)
+monitors.append( mnModel(filename="output/bears_nodedate_only_fossil_data.log", printgen=10)	)
 
-# 2. the tree #
-monitors.append( mnFile(filename="output/bears_nodedate.trees", printgen=10, timetree) )
-
-# 3. and a few select parameters to be printed to the screen #
+# 2. and a few select parameters to be printed to the screen #
 monitors.append( mnScreen(printgen=10, extant_mrca, diversification) )
 
 # Initialize the MCMC object #
@@ -61,16 +61,6 @@ mymcmc = mcmc(mymodel, monitors, moves, nruns=2, combine="mixed")
 
 # Run the MCMC #
 mymcmc.run(generations=20000, tuningInterval=200)
-
-########################
-# Summarizing the tree #
-########################
-
-# Read the trace file #
-trace = readTreeTrace("output/bears_nodedate.trees")
-
-# Maximum clade credibility tree #
-mccTree(trace, file="output/bears_nodedate.mcc.tre" )
 
 # Quit RevBayes #
 q()

--- a/tutorials/dating/scripts/clock_global.Rev
+++ b/tutorials/dating/scripts/clock_global.Rev
@@ -5,4 +5,4 @@
 # we assume a strict morphological clock rate, drawn from an exponential prior #
 branch_rates ~ dnExponential(10.0)
 
-moves.append( mvScale(branch_rates,lambda=0.5,tune=true,weight=3.0) )
+moves.append( mvScale(branch_rates, lambda=0.5, tune=true, weight=3.0) )

--- a/tutorials/dating/scripts/sub_GTRG.Rev
+++ b/tutorials/dating/scripts/sub_GTRG.Rev
@@ -15,8 +15,8 @@ sf ~ dnDirichlet(sf_hp)
 er_hp <- v(1,1,1,1,1,1)
 er ~ dnDirichlet(er_hp)
 
-moves.append( mvBetaSimplex(er, alpha=10.0, weight=2.0) )
-moves.append( mvBetaSimplex(sf, alpha=10.0, weight=3.0) )
+moves.append( mvBetaSimplex(er, alpha=10.0, weight=3.0) )
+moves.append( mvBetaSimplex(sf, alpha=10.0, weight=2.0) )
 
 # Create the matrix #
 Q_cytb := fnGTR(er,sf)

--- a/tutorials/dating/scripts/tree_BD.Rev
+++ b/tutorials/dating/scripts/tree_BD.Rev
@@ -7,10 +7,10 @@ speciation_rate ~ dnExponential(10)
 extinction_rate ~ dnExponential(10)
 
 # Specify a scale move on the speciation_rate parameter #
-moves.append( mvScale(speciation_rate, lambda=0.5,tune=true,weight=3.0) )
+moves.append( mvScale(speciation_rate, lambda=0.5, tune=true, weight=3.0) )
 
 # Specify a scale move on the extinction_rate parameter #
-moves.append( mvScale(extinction_rate, lambda=0.5,tune=true,weight=3.0) )
+moves.append( mvScale(extinction_rate, lambda=0.5, tune=true, weight=3.0) )
 
 # Create deterministic nodes for the diversification and turnover rates to monitor these parameters #
 diversification := speciation_rate - extinction_rate
@@ -36,7 +36,7 @@ timetree ~ dnConstrainedTopology(tree_dist, constraints=constraints)
 
 # Specify moves on the tree and node times #
 moves.append( mvNarrow(timetree, weight=n_taxa) )
-moves.append( mvFNPR(timetree, weight=n_taxa/4.0) )
+moves.append( mvFNPR(timetree, weight=n_taxa/4) )
 moves.append( mvNodeTimeSlideUniform(timetree, weight=n_taxa) )
 moves.append( mvSubtreeScale(timetree, weight=n_taxa/5.0) )
 

--- a/tutorials/dating/scripts/tree_BD_nodedate.Rev
+++ b/tutorials/dating/scripts/tree_BD_nodedate.Rev
@@ -41,9 +41,10 @@ constraints = v(clade_ursinae)
 timetree ~ dnConstrainedTopology(tree_dist, constraints=constraints)
 
 # Specify moves on the tree and node times #
-moves.append( mvNarrow(timetree, weight=n_taxa/2.0) )
-moves.append( mvFNPR(timetree, weight=n_taxa/10.0) )
+moves.append( mvNarrow(timetree, weight=n_taxa) )
+moves.append( mvFNPR(timetree, weight=n_taxa/4) )
 moves.append( mvNodeTimeSlideUniform(timetree, weight=n_taxa) )
+moves.append( mvSubtreeScale(timetree, weight=n_taxa/5.0) )
 
 # Monitor the age of Ursinae #
 age_ursinae := tmrca(timetree, clade_ursinae)

--- a/tutorials/dating/test.sh
+++ b/tutorials/dating/test.sh
@@ -1,6 +1,0 @@
-sed -i.bak 's/generations=20000/generations=1/g' scripts/MCMC_dating_ex2.Rev
-${rb_exec} -b scripts/MCMC_dating_ex2.Rev
-res="$?"
-mv scripts/MCMC_dating_ex2.Rev.bak scripts/MCMC_dating_ex2.Rev
-rm -rf output
-exit $res

--- a/tutorials/dating/tests.txt
+++ b/tutorials/dating/tests.txt
@@ -1,0 +1,5 @@
+MCMC_dating_ex1.Rev
+MCMC_dating_ex2.Rev
+MCMC_dating_ex2b.Rev
+MCMC_dating_ex3.Rev
+MCMC_dating_ex3_only_fossil_data.Rev

--- a/tutorials/fbd/test.sh
+++ b/tutorials/fbd/test.sh
@@ -1,6 +1,0 @@
-sed -i.bak 's/generations=10000/generations=1/g' scripts/mcmc_CEFBDP_Specimens.Rev
-${rb_exec} -b scripts/mcmc_CEFBDP_Specimens.Rev
-res="$?"
-mv scripts/mcmc_CEFBDP_Specimens.Rev.bak scripts/mcmc_CEFBDP_Specimens.Rev
-rm -rf output
-exit $res

--- a/tutorials/fbd/tests.txt
+++ b/tutorials/fbd/tests.txt
@@ -1,0 +1,1 @@
+mcmc_CEFBDP_Specimens.Rev


### PR DESCRIPTION
To make tutorial tests more straightforward, and to allow `revbayes/tests/run_integration_tests.sh` to run multiple tutorial tests, I restructured how these tests are run. I moved all the test preparations (i.e. creating copies of scripts, changing the number of MCMC gens to 1) to `run_integration_tests.sh`, then deleted the `test.sh` scripts contained in three tutorials (fbd_specimen, dating, ctmc), and added `tests.txt` instead, which simply lists one script per line from the `scripts` directory. In this way, tutorial developers can choose which scripts need to be run to satisfactorily test the tutorial, and all of those can be run (e.g. in the fbd_specimen tutorial, only `mcmc_CEFBDP_Specimens.Rev` need be run, and all other scripts in `scripts` are auxiliary; in the ctmc tutorial, there are multiple auxiliary and multiple master scripts, so `tests.txt` is necessary). I will push my changes to `revbayes/tests/run_integration_tests.sh` when these website changes are live and I've updated the submodule in the revbayes repo, so as to ensure that the test script is working.

Since I reviewed the fbd_specimen, dating and ctmc tutorial to make the changes above, I also spent some time making sure that the scripts in the `scripts` directory match the html on the website. This included multiple changes to both scripts and tutorial md files, mostly typos and minor changes. Now we can ensure that if the tutorial tests for these files passes, then the website tutorial works.