### PR TITLE
Modified dating tutorial to include code snippets pulling directly from scripts

### DIFF
--- a/tutorials/dating/global.md
+++ b/tutorials/dating/global.md
@@ -16,6 +16,11 @@ include_files:
 index: false
 ---
 
+{% assign ex1_script = "MCMC_dating_ex1.Rev" %}
+{% assign global_script = "clock_global.Rev" %}
+{% assign gtrg_script = "sub_GTRG.Rev" %}
+{% assign bd_script = "tree_BD.Rev" %}
+
 Exercise 1
 ===========
 {:.section}
@@ -46,20 +51,17 @@ In this exercise you will create separate files for the substitution model, cloc
 #### Reading the data
 
 First, we'll begin the Rev script by importing the cytochrome b sequences and assign the data matrix to a variable called `cytb`.
-```
-cytb <- readDiscreteCharacterData("data/bears_cytb.nex")
-```
+
+{{ ex1_script | snippet:"block#", "1" }}
+
 At this stage we'll also create some useful variables for later, including the number of taxa `n_taxa` and a vector of taxa that we can extract from the alignment data using `cytb.taxa`.
-```
-n_taxa <- cytb.size()
-taxa <- cytb.taxa()
-```
+
+{{ ex1_script | snippet:"block#", "2" }}
+
 We will also create a workspace variable called `moves` and `monitors`.
 This variable is a vector containing all of the MCMC moves and monitors respectively.
-```
-moves    = VectorMoves()
-monitors = VectorMonitors()
-```
+
+{{ ex1_script | snippet:"block#", "3" }}
 
 >Don't forget to save your changes at the end of each section!
 {:.instruction}
@@ -78,38 +80,35 @@ monitors = VectorMonitors()
 This script will contain all the parameters in our birth-death tree model, which is used to describe the process that generated our tree. Since all of the taxa included in the analysis in this exercise are living species we'll use a birth-death model that doesn't incorporate the fossil recovery process. Two key parameters in this model are the speciation rate (the rate at which lineages are added to the tree, denoted by $\lambda$) and the extinction rate (the rate at which lineages are removed from the tree, $\mu$). We will assume that these rates are constant over time and place exponential priors on each of these. Each parameter is assumed to be drawn independently from a different exponential distribution with rates $\delta_\lambda$ and $\delta_\mu$, with $\delta_\lambda$ = $\delta_\mu$ = 10. Note an exponential distribution with $\delta = 10$ has an expected value (mean) of $1/\delta$ = 0.1.
 
 Create the exponentially distributed stochastic nodes for `speciation_rate` and `extinction_rate` using the `~` operator.
-```
-speciation_rate ~ dnExponential(10)
-extinction_rate ~ dnExponential(10)
-```
+
+{{ bd_script | snippet:"block#", "1" }}
+
 For every stochastic node we declare, we must also specify moves (or proposal algorithms) to sample the value of the parameter in proportion to its posterior probability. If a move is not specified for a stochastic node, then it will not be estimated, but fixed to its initial value.
 
 The rate parameters for extinction and speciation are both positive, real numbers (i.e. non-negative floating point variables). For both of these nodes, we will use a scaling move (`mvScale`), which proposes multiplicative changes to a parameter. Many moves also require us to set a tuning value, called `lambda` for `mvScale`, which determine the size of the proposed change. Here, we will also use `tune=true`, which will alter the magnitude of the proposed changes after an intital tuning phase. Note there are many different strategies available in RevBayes for improving mixing and convergence. See the tutorial {% page_ref mcmc_troubleshooting %} for more information on this topic.
-```
-moves.append( mvScale(speciation_rate, lambda=0.5, tune=true, weight=3.0) )
-moves.append( mvScale(extinction_rate, lambda=0.5, tune=true, weight=3.0) )
-```
+
+{{ bd_script | snippet:"block#", "2-3" }}
+
 The `weight` option allows you to indicate how many times you would like a given move to be performed at each MCMC cycle. In this tutorial we will execute a *schedule* of moves at each step in our chain instead of just one move per step. Here, if we were to run our MCMC with our current vector of 6 moves, then our move schedule would perform 6 moves at each cycle. Within a cycle, an individual move is chosen from the move list in proportion to its weight. Therefore, with all six moves assigned `weight=1`, each has an equal probability of being executed and will be performed on average one time per MCMC cycle. For more information on moves and how they are performed in RevBayes, please refer to the {% page_ref mcmc %} and {% page_ref ctmc %} tutorials.
 
 In addition to the speciation ($\lambda$) and extinction ($\mu$) rates, we may also be interested in inferring diversification ($\lambda - \mu$) and turnover ($\mu/\lambda$). Since these parameters can be expressed as a deterministic transformation of the speciation and extinction rates, we can monitor (that is, track the values of these parameters, and print them to a file) their values by creating two deterministic nodes using the `:=` operator.
-```
-diversification := speciation_rate - extinction_rate
-turnover := extinction_rate/speciation_rate
-```
+
+{{ bd_script | snippet:"block#", "4" }}
+
 $\rho$ is the probability of extant species sampling. Since we sample all extant bears, we'll specify this probability as a constant node = 1.0 using the `<-` operator.
-```
-rho <- 1.0
-```
+
+{{ bd_script | snippet:"block#", "5" }}
+
 Because $\rho$ is a constant node, we do not have to assign any moves to this parameter.
 
 Since in this exercise our aim is to infer relative times only, we'll simply fix the root age to an arbitrary value = 1.0. In this exercise the root is the MRCA of all living bears.
-```
-extant_mrca <- 1.0
-```
+
+{{ bd_script | snippet:"block#", "6" }}
+
 Now that we've specified all of the parameters of the birth-death model, we can use these parameters to define the prior distribution on the tree topology and divergence times.
-```
-tree_dist = dnBDP(lambda=speciation_rate, mu=extinction_rate, rho=rho, rootAge=extant_mrca, samplingStrategy="uniform", condition="nTaxa", taxa=taxa)
-```
+
+{{ bd_script | snippet:"block#", "7" }}
+
 Note that we created the distribution as a workspace variable using the workspace assignment operator `=`. This is because we still need to include a topology constraint in our final specification of the tree prior.
 
 
@@ -119,26 +118,19 @@ Note that we created the distribution as a workspace variable using the workspac
 In some cases we may want to constrain parts of the tree topology based on prior information. This is often necessary when we incorporate fossil calibration information, which we'll do in subsequent tutorial exercises.
 
 Here, we will constrain the group Ursinae to be monophyletic by first creating a vector of constraints.
-```
-clade_ursinae = clade("Melursus_ursinus", "Ursus_arctos", "Ursus_maritimus", "Helarctos_malayanus", "Ursus_americanus", "Ursus_thibetanus")                      
-constraints = v(clade_ursinae)
-```
+
+{{ bd_script | snippet:"block#", "8" }}
+
 Next, we will specify the final constrained tree prior distribution, providing the constraints along with the workspace birth-death distribution to the constrained topology distribution. Here we use the stochastic assignment operator `~` to create a stochastic node for our constrained tree variable `timetree`.
-```
-timetree ~ dnConstrainedTopology(tree_dist, constraints=constraints)
-```
 
-
+{{ bd_script | snippet:"block#", "9" }}
 
 #### Moves on the tree
 
 The final step in our tree model script is to add the moves for the tree topology (`mvFNPR`) and node ages (`mvNodeTimeSlideUniform`).
-```
-moves.append( mvNarrow(timetree, weight=n_taxa) )
-moves.append( mvFNPR(timetree, weight=n_taxa/4) )
-moves.append( mvNodeTimeSlideUniform(timetree, weight=n_taxa) )
-moves.append( mvSubtreeScale(timetree, weight=n_taxa/5.0) )
-```
+
+{{ bd_script | snippet:"block#", "10" }}
+
 Note there are lots of moves available for trees in RevBayes that you can use to improve the mixing, which you can learn about in other tutorials, including [Divergence Time Calibration](https://github.com/revbayes/revbayes_tutorial/blob/master/tutorial_TeX/RB_DivergenceTime_Calibration_Tutorial/).
 
 
@@ -146,9 +138,9 @@ Note there are lots of moves available for trees in RevBayes that you can use to
 #### Monitoring node ages of interest
 
 We may be interested in monitoring the age of a given node in our MCMC sample. We can do this by first using the `clade` function to specify the node of interest, as we have done above for Ursinae. Once a clade is defined we can instantiate a deterministic node, in this case `age_ursinae`, with the `tmrca` function that will record the age of this node.
-```
-age_ursinae := tmrca(timetree, clade_ursinae)
-```
+
+{{ bd_script | snippet:"block#", "11" }}
+
 Note that if we had not included this clade in the constraints that defined the `timetree` variable, this node would not be constrained to be monophyletic, but we could still monitor the age using the `tmrca` approach.
 
 
@@ -164,12 +156,8 @@ In this exercise we'll use the global molecular clock model that assumes rates a
 For the branch-rates parameter we will use an exponential prior, with rate parameter $\delta_c$ = 10. Recall that the expected value (or mean) of this distribution is 0.1. The same branch-rate will apply to every branch in the tree.
 
 Create the exponentially distributed stochastic node for `branch_rates` and assign a move to this parameter.
-```
-branch_rates ~ dnExponential(10.0)
-moves.append( mvScale(branch_rates, lambda=0.5, tune=true, weight=3.0) )
-```
 
-
+{{ global_script | snippet:"block#", "1" }}
 
 ### The substitution model
 
@@ -182,39 +170,28 @@ For this exercise we will use the general time-reversible (GTR) + $\Gamma$ model
 
 First, we need to define an instantaneous-rate matrix (i.e. a Q-matrix).
 A nucleotide GTR matrix is defined by a set of 4 stationary frequencies, and 6 exchangeability rates. Create stochastic nodes for these variables, each drawn from a uniform Dirichlet prior distribution.
-```
-sf_hp <- v(1,1,1,1)
-sf ~ dnDirichlet(sf_hp)
 
-er_hp <- v(1,1,1,1,1,1)
-er ~ dnDirichlet(er_hp)
-```
+{{ gtrg_script | snippet:"block#", "1-2" }}
+
 We need special moves to propose changes to a Dirichlet random variable, also known as a simplex (a vector constrained to sum to one). Here, we use a `mvSimplexElementScale` move, which scales a single element of a simplex and then renormalises the vector to sum to one. The tuning parameter `alpha` specifies how conservative the proposal should be, with larger values of alpha leading to proposals closer to the current value.
-```
-moves.append( mvBetaSimplex(er, alpha=10.0, weight=3.0) )
-moves.append( mvBetaSimplex(sf, alpha=10.0, weight=2.0) )
-```
+
+{{ gtrg_script | snippet:"block#", "3" }}
+
 Then we can define a deterministic node for our GTR Q-matrix using the special GTR matrix function (`fnGTR`).
-```
-Q_cytb := fnGTR(er,sf)
-```
+
+{{ gtrg_script | snippet:"block#", "4" }}
+
 Next, in order to model gamma-distributed rates across sites, we will create an exponential parameter $\alpha$ for the shape of the gamma distribution, along with scale proposals.
-```
-alpha_cytb ~ dnUniform(0.0,1E6)
-alpha_cytb.setValue( 1.0 )
 
-moves.append( mvScale(alpha_cytb, lambda=0.5, tune=true, weight=2.0) )
-```
+{{ gtrg_script | snippet:"block#", "5-6" }}
+
 Then we create a gamma distribution, discretized into 4 rate categories using the `fnDiscretizeGamma` function. Here, `rates_cytb` is a deterministic vector of rates computed as the mean of each category.
-```
-rates_cytb := fnDiscretizeGamma(alpha_cytb, alpha_cytb, 4)
-```
-Finally, we can create the phylogenetic continuous time Markov chain (PhyloCTMC) distribution for our sequence data, including the gamma-distributed site rate categories, as well as the branch rates defined as part of our clock model. We set the value of this distribution equal to our observed data and identify it as a static part of the likelihood using the clamp method.
-```
-phySeq ~ dnPhyloCTMC(tree=timetree, Q=Q_cytb, siteRates=rates_cytb, branchRates=branch_rates, type="DNA")
-phySeq.clamp(cytb)
-```
 
+{{ gtrg_script | snippet:"block#", "7" }}
+
+Finally, we can create the phylogenetic continuous time Markov chain (PhyloCTMC) distribution for our sequence data, including the gamma-distributed site rate categories, as well as the branch rates defined as part of our clock model. We set the value of this distribution equal to our observed data and identify it as a static part of the likelihood using the clamp method.
+
+{{ gtrg_script | snippet:"block#", "8-9" }}
 
 ### Setting up the MCMC
 
@@ -222,50 +199,46 @@ phySeq.clamp(cytb)
 {:.instruction}
 
 RevBayes uses the `source` function to load commands from Rev files into the workspace. Use this function to load in the model scripts you have written in the text editor and saved in the **scripts** directory.
-```
-source("scripts/tree_BD.Rev") # BD tree prior
-source("scripts/clock_global.Rev") # the global clock model
-source("scripts/sub_GTR.Rev") # the GTR model
-```
+
+{{ ex1_script | snippet:"block#", "4-6" }}
+
 We can now create our workspace model variable with our fully specified model DAG. We will do this with the `model` function and provide a single node in the graph (`sf`).
-```
-mymodel = model(sf)
-```
+
+{{ ex1_script | snippet:"block#", "7" }}
+
 The object `mymodel` is a wrapper around the entire model graph and allows us to pass the model to various functions that are specific to our MCMC analysis.
 
 The next important step for our master Rev file is to specify the monitors and output file names. For this, we will create a vector called `monitors` that will each sample and record or output our MCMC.
 
 The first monitor we will create will monitor every named random variable in our model graph. This will include every stochastic and deterministic node using the `mnModel` monitor. The only parameter that is not included in the `mnModel` is the tree topology. Therefore, the parameters in the file written by this monitor are all numerical parameters and will be written to a tab-separated text file that can be opened by accessory programs for evaluating such parameters. We will also name the output file for this monitor and indicate that we wish to sample our MCMC every 10 cycles.
-```
-monitors.append( mnModel(filename="output/bears_global.log", printgen=10) )
-```
+
+{{ ex1_script | snippet:"block#", "8" }}
+
 The `mnFile` monitor writes any parameter we specify to file. Thus, if we only cared about the speciation rate and nothing else (this is not a typical or recommended attitude for an analysis this complex) we wouldn’t use the `mnModel` monitor above and just use the `mnFile` monitor to write a smaller and simpler output file. Since the tree topology is not included in the `mnModel` monitor (because it is not numerical), we will use `mnFile` to write the tree to file by specifying our `timetree` variable in the arguments.
-```
-monitors.append( mnFile(filename="output/bears_global.trees", printgen=10, timetree) )
-```
+
+{{ ex1_script | snippet:"block#", "9" }}
+
 The last monitor we will add to our analysis will print information to the screen. As with `mnFile` we must tell `mnScreen` which parameters we’d like to see updated on the screen. We will choose the age of the MRCA of living bears (`extant_mrca`) and the diversification rate (`diversification`) parameters.
-```
-monitors.append( mnScreen(printgen=10, extant_mrca, diversification) )
-```
+
+{{ ex1_script | snippet:"block#", "10" }}
+
 Once we have set up our model, moves, and monitors, we can now create the workspace variable that defines our MCMC run. We do this using the `mcmc` function that simply takes the three main analysis components as arguments.
-```
-mymcmc = mcmc(mymodel, monitors, moves, nruns=2, combine="mixed")
-```
+
+{{ ex1_script | snippet:"block#", "11" }}
+
 The MCMC object that we named `mymcmc` has a member method called run. This will execute our analysis and we will set the chain length to 20000 cycles using the generations option.
-```
-mymcmc.run(generations=20000, tuningInterval=200)
-```
+
+{{ ex1_script | snippet:"block#", "12" }}
+
 After the Markov chain has completed, we can create a summary tree. We'll use the function `readTreeTrace` to read the MCMC sample of trees from file and the command `mccTree` to generate the maximum clade credibility (MCC) tree.
-```
-trace = readTreeTrace("output/bears_global.trees")
-mccTree(trace, file="output/bears_global.mcc.tre")
-```
+
+{{ ex1_script | snippet:"block#", "13-14" }}
+
 Note by default, a burn-in of 25% is used when creating the tree trace (250 trees in our case). You can specify a different burn-in fraction, say 50%, by typing the command `trace.setBurnin(500)`.
 
 Once all our analysis is complete, we will want RevBayes to close. Tell the program to quit using the `q()` function.
-```
-q()
-```
+
+{{ ex1_script | snippet:"block#", "15" }}
 
 >Execute your MCMC analysis in RevBayes!
 {:.instruction}

--- a/tutorials/dating/relaxed.md
+++ b/tutorials/dating/relaxed.md
@@ -15,6 +15,11 @@ index: false
 redirect: false
 ---
 
+{% assign ex2_script = "MCMC_dating_ex2.Rev" %} 
+{% assign ex2b_script = "MCMC_dating_ex2b.Rev" %}
+{% assign exp_script = "clock_relaxed_exponential.Rev" %} 
+{% assign lnorm_script = "clock_relaxed_lognormal.Rev" %}
+
 Exercise 2
 ===========
 {:.section}
@@ -47,21 +52,17 @@ Remember the clock (or branch-rate) model describes how rates of substitution va
 We are going to use the uncorrelated exponential relaxed clock model. In this model rates for each branch will be drawn independently from an exponential distribution. 
 
 It's a bit more tricky to set up this clock model. First, we'll define the mean branch rate as an exponential random variable (`branch_rates_mean`). Then, specify a scale proposal move on this parameter.
-```
-branch_rates_mean ~ dnExponential(10.0)
-moves.append( mvScale(branch_rates_mean, lambda=0.5, tune=true, weight=3.0) )
-```
+
+{{ exp_script | snippet:"block#", "1-2" }}
+
 Before creating a rate parameter for each branch, we need to define the number of branches in the tree. For rooted trees with $n$ taxa, the number of branches is $2n−2$.
-```
-n_branches <- 2 * n_taxa - 2
-```
+
+{{ exp_script | snippet:"block#", "3" }}
+
 Then, use a for loop to define a rate for each branch. The branch rates are independent and identically exponentially distributed with mean equal to the mean branch rate parameter we specified above. For each rate parameter we will also create scale proposal moves.
-```
-for(i in 1:n_branches){
-    branch_rates[i] ~ dnExp(1/branch_rates_mean)
-    moves.append( mvScale(branch_rates[i], lambda=0.5, tune=true, weight=1.0) )
-}
-```	
+
+{{ exp_script | snippet:"block#", "4" }}
+
 Note that now we have a vector of rates `branch_rates`, where each entry corresponds to a different branch in the tree, instead of a single rate that applies to all branches.	
 Lastly, we will use two more specific moves to help improve MCMC convergence.
 First, we will use a vector scale move to propose changes to all branch rates simultaneously. 
@@ -69,11 +70,8 @@ This way we can sample the total branch rate independently of each individual ra
 Second, we will use a move (`mvRateAgeBetaShift`) that changes the node ages and branch rates jointly,
 so that the effective branch length (the product of branch time and branch rate) remains the same.
 Thus, the move is proposing values with the same likelihood but a different prior probability.
-```
-moves.append( mvVectorScale(branch_rates, lambda=0.5, tune=true, weight=4.0) )
-moves.append( mvRateAgeBetaShift(tree=timetree, rates=branch_rates, tune=true, weight=n_taxa) )
-```
 
+{{ exp_script | snippet:"block#", "5" }}
 
 ### The master Rev script
 
@@ -81,19 +79,17 @@ moves.append( mvRateAgeBetaShift(tree=timetree, rates=branch_rates, tune=true, w
 {:.instruction}
 
 First, change the file used to specify the clock model from **clock_global.Rev** to **clock_relaxed_exponential.Rev**.
-```
-source("scripts/clock_relaxed_exponential.Rev")
-```
+
+{{ ex2_script | snippet:"block#", "5" }}
+
 Second, update the name of all the output files.
-```
-monitors.append( mnModel(filename="output/bears_relaxed_exponential.log", printgen=10) )
-monitors.append( mnFile(filename="output/bears_relaxed_exponential.trees", printgen=10, timetree) )
-```
+
+{{ ex2_script | snippet:"block#", "8-9" }}
+
 Don't forget to update the commands used to generate the summary tree.
-```
-trace = readTreeTrace("output/bears_relaxed_exponential.trees")
-mccTree(trace, file="output/bears_relaxed_exponential.mcc.tre" )
-```
+
+{{ ex2_script | snippet:"block#", "13-14" }}
+
 That's all you need to do!
 
 >Run your MCMC analysis!
@@ -169,25 +165,22 @@ That means, we will need to replace the prior on the `branch_rates` so that they
 {:.instruction}
 
 Since the lognormal distribution is parameterized by the log of the mean, we transform first the mean into the log mean.
-```
-ln_branch_rates_mean := ln( branch_rates_mean )
-```
+
+{{ lnorm_script | snippet:"block#", "2" }}
+
 Now we can replace the `for`-loop and specify that we use a lognormal distribution
-```
-for(i in 1:n_branches){
-    branch_rates[i] ~ dnLognormal(ln_branch_rates_mean,sd=0.587405)
-    moves.append( mvScale(branch_rates[i], lambda=0.5, tune=true, weight=1.0) )
-}
-```	
+
+{{ lnorm_script | snippet:"block#", "5" }}
+
 Next, we are ready to set up the master script to run the analysis.
 
 >Copy the master script from the previous exercise and call it **MCMC_dating_ex2b.Rev**. 
 {:.instruction}
 
 Change the file used to specify the clock model from **clock_relaxed_exponential.Rev** to **clock_relaxed_lognormal.Rev**.
-```
-source("scripts/clock_relaxed_lognormal.Rev")
-```
+
+{{ ex2b_script | snippet:"block#", "5" }}
+
 Don't forget to update the filenames of the output (*e.g.,* from `bears_relaxed_exponential` to `bears_relaxed_lognormal`).
 
 >Run your MCMC analysis!

--- a/tutorials/dating/scripts/MCMC_dating_ex1.Rev
+++ b/tutorials/dating/scripts/MCMC_dating_ex1.Rev
@@ -58,7 +58,7 @@ monitors.append( mnModel(filename="output/bears_global.log", printgen=10) )
 monitors.append( mnFile(filename="output/bears_global.trees", printgen=10, timetree) )
 
 # 3. and a few select parameters to be printed to the screen #
-monitors.append( mnScreen(printgen=100, extant_mrca, diversification) )
+monitors.append( mnScreen(printgen=10, extant_mrca, diversification) )
 
 # Initialize the MCMC object #
 mymcmc = mcmc(mymodel, monitors, moves, nruns=2, combine="mixed")

--- a/tutorials/dating/scripts/clock_global.Rev
+++ b/tutorials/dating/scripts/clock_global.Rev
@@ -4,5 +4,4 @@
 
 # we assume a strict morphological clock rate, drawn from an exponential prior #
 branch_rates ~ dnExponential(10.0)
-
 moves.append( mvScale(branch_rates, lambda=0.5, tune=true, weight=3.0) )

--- a/tutorials/dating/scripts/tree_BD.Rev
+++ b/tutorials/dating/scripts/tree_BD.Rev
@@ -28,7 +28,7 @@ tree_dist = dnBDP(lambda=speciation_rate, mu=extinction_rate, rho=rho, rootAge=e
 
 # Define clade constraints #
 clade_ursinae = clade("Melursus_ursinus", "Ursus_arctos", "Ursus_maritimus", 
-                  "Helarctos_malayanus", "Ursus_americanus", "Ursus_thibetanus")                      
+                  "Helarctos_malayanus", "Ursus_americanus", "Ursus_thibetanus") 
 constraints = v(clade_ursinae)
 
 # Define a stochastic node for the constrained tree topology #


### PR DESCRIPTION
Modified `dating` tutorial to connect scripts and markdown (I also did the `ctmc` tutorial and accidentally deployed already). Each `.md` file in `tutorials/dating/` now pulls code directly from scripts. Only change this induced is including some extra comments and whitespace on certain codeblocks. I don't think that's a big deal, but would be willing to modify scripts further to avoid it if needed.