### PR TITLE
Made tutorial modules the entry tutorials page.

### DIFF
--- a/home/all_tutorials.md
+++ b/home/all_tutorials.md
@@ -1,0 +1,77 @@
+---
+layout: home
+title: Tutorials
+subtitle: RevBayes Tutorials
+permalink: /all_tutorials/
+levels:
+- Introduction to RevBayes
+- Introduction to MCMC
+- Model Selection and Testing
+- Standard tree inference
+- Complex hierarchical models for phylogenetic inference
+- Discrete Morphology
+- Comparative methods
+- Diversification Rate Estimation
+- Biogeography
+- Demographic Inference
+levels_id:
+- intro
+- mcmc
+- model_test
+- phylo_basic
+- phylo_complex
+- phylo_div_rate
+- phylo_trait
+- phylo_biogeo
+- demographic
+---
+
+This list shows all of the RevBayes tutorials for learning various aspects of RevBayes and Bayesian phylogenetic analysis.
+Each one explicitly walks you through model specification and analysis set-up for different phylogenetic methods.
+These tutorials have been written for new users to learn RevBayes at home, at workshops, and in courses taught at the undergraduate and graduate levels.
+You may find that the styles are somewhat different between tutorials and that some  have overlapping content.
+
+Please see the {% page_ref format %} guide for details about how to read the tutorials.
+
+Please see {% page_ref recommended %} for links to various software programs you may need to download in order to follow the tutorials.
+
+<a href="{% page_url tutorial %}" class="btn btn-warning" role="button">Contribute!</a>
+
+{% comment %}
+{% include keywords.html input=true %}
+{% assign keywords = site.empty_array %}
+{% endcomment %}
+
+{% assign levels = site.tutorials | sort:"level","last" | group_by:"level" %}
+{% for level in levels %}
+{% assign i = forloop.index | minus: 1 %}
+{% if page.levels[i] %}
+<h3>{{ page.levels[i] }}</h3>{:id="{{ page.levels_id[i] }}"}
+{% else %}
+<h3>Miscellaneous Tutorials</h3>
+{% endif %}
+
+{% assign tutorials = level.items | sort:"order","last" %}
+
+<div class="tutorialbox">
+{% for tutorial in tutorials %}
+{% if tutorial.index %}
+
+{% comment %}{% assign keywords = tutorial.keywords | concat: keywords %}{% endcomment %}
+
+<div class="tutorial {{ tutorial.keywords | join:' '}}">
+{% if tutorial.title-old and tutorial.redirect %}
+<a class="title" href="https://github.com/revbayes/revbayes_tutorial/raw/master/tutorial_TeX/{{ tutorial.title-old }}/{{ tutorial.title-old }}.pdf">{{ tutorial.title | markdownify }}</a>
+{% else %}
+<a class="title" href="{{ site.baseurl }}{{ tutorial.url }}">{{ tutorial.title | markdownify }}</a>
+{% endif %}
+<p class="subtitle" >{{ tutorial.subtitle | markdownify }}</p>
+</div>
+{% endif %}
+
+{% endfor %}
+</div>
+
+{% endfor %}
+
+{% comment %}{% include keywords.html script=true %}{% endcomment %}

--- a/home/tutorials.md
+++ b/home/tutorials.md
@@ -1,77 +1,152 @@
 ---
 layout: home
-title: Tutorials
-subtitle: RevBayes Tutorials
 permalink: /tutorials/
-levels:
-- Introduction to RevBayes
-- Introduction to MCMC
-- Model Selection and Testing
-- Standard tree inference
-- Complex hierarchical models for phylogenetic inference
-- Discrete Morphology
-- Comparative methods
-- Diversification Rate Estimation
-- Biogeography
-- Demographic Inference
-levels_id:
-- intro
-- mcmc
-- model_test
-- phylo_basic
-- phylo_complex
-- phylo_div_rate
-- phylo_trait
-- phylo_biogeo
-- demographic
+title: Tutorials
+subtitle: Tutorial modules
 ---
 
-This list shows all of the RevBayes tutorials for learning various aspects of RevBayes and Bayesian phylogenetic analysis.
-Each one explicitly walks you through model specification and analysis set-up for different phylogenetic methods.
-These tutorials have been written for new users to learn RevBayes at home, at workshops, and in courses taught at the undergraduate and graduate levels.
-You may find that the styles are somewhat different between tutorials and that some  have overlapping content.
+This page is intended to guide users in assembling a set of tutorials that will help them learn 
+how to use RevBayes for a given analysis. Each module lists the tutorials that focus on a particular 
+topic, as well as those that will provide prerequisite knowledge or resources for deeper learning.    
+We encourage users with no RevBayes experience to start with the **RevBayes fundamentals** module.
 
-Please see the {% page_ref format %} guide for details about how to read the tutorials.
+To see all available tutorials, including the ones for which modules are not currently written, 
+go to the [full tutorials page]({{ base.url }}/all_tutorials).
 
-Please see {% page_ref recommended %} for links to various software programs you may need to download in order to follow the tutorials.
+{% aside RevBayes fundamentals %}
 
-<a href="{% page_url tutorial %}" class="btn btn-warning" role="button">Contribute!</a>
+This module is for users who have no experience with RevBayes. The tutorials contained here walk
+the user through the basics of installing and using RevBayes, and some of the theory behind
+RevBayes analyses.
 
-{% comment %}
-{% include keywords.html input=true %}
-{% assign keywords = site.empty_array %}
-{% endcomment %}
+- Pre-requisites: Basic knowledge on Bayesian statistics.
 
-{% assign levels = site.tutorials | sort:"level","last" | group_by:"level" %}
-{% for level in levels %}
-{% assign i = forloop.index | minus: 1 %}
-{% if page.levels[i] %}
-<h3>{{ page.levels[i] }}</h3>{:id="{{ page.levels_id[i] }}"}
-{% else %}
-<h3>Miscellaneous Tutorials</h3>
-{% endif %}
+1. [Getting started with RevBayes]({{ base.url }}/tutorials/intro/getting_started). This tutorial includes getting RevBayes working on your machine, and learning about the fundamentals of setting up models in the software.
+2. MCMC fundamentals. Three tutorials lay out the basics of Markov Chain Monte Carlo analysis in RevBayes, using three different examples: [Airline fatalities]({{ base.url }}/tutorials/mcmc/poisson), [coin flips]({{ base.url }}/tutorials/mcmc/binomial), and [archery]({{ base.url }}/tutorials/mcmc/archery). It is recommended that absolute beginners go through all three.
 
-{% assign tutorials = level.items | sort:"order","last" %}
+By the end of this module, you should be able to build RevBayes, write simple Rev code, and build 
+simple models on which to run MCMC analyses. From here, you can select the module(s) below that
+best represent your interests and intended analyses.
 
-<div class="tutorialbox">
-{% for tutorial in tutorials %}
-{% if tutorial.index %}
+{% endaside %}
 
-{% comment %}{% assign keywords = tutorial.keywords | concat: keywords %}{% endcomment %}
+{% aside MCMC assessment %}
 
-<div class="tutorial {{ tutorial.keywords | join:' '}}">
-{% if tutorial.title-old and tutorial.redirect %}
-<a class="title" href="https://github.com/revbayes/revbayes_tutorial/raw/master/tutorial_TeX/{{ tutorial.title-old }}/{{ tutorial.title-old }}.pdf">{{ tutorial.title | markdownify }}</a>
-{% else %}
-<a class="title" href="{{ site.baseurl }}{{ tutorial.url }}">{{ tutorial.title | markdownify }}</a>
-{% endif %}
-<p class="subtitle" >{{ tutorial.subtitle | markdownify }}</p>
-</div>
-{% endif %}
+This module is for users looking to debug or analyze their MCMC results deeper. The tutorials will walk the user through best practices when analyzing posterior samples, and tips on how to improve your analyses if your analysis has not converged.
 
-{% endfor %}
-</div>
+- Pre-requisites: **RevBayes fundamentals**, and results from some analysis (e.g. from completion of one of the modules below).
 
-{% endfor %}
+1. Assessing convergence of your MCMC results: [Convergence assessment]({{ base.url }}/tutorials/convergence). This tutorial will walk you through theory and examples on how to assess the convergence of your MCMC chain.
+2. Practical exercises on assessing convergence: [Debugging your MCMC]({{ base.url }}/tutorials/mcmc_troubleshooting). This tutorial contains more exercises on assessing convergence, and provides tips on how to improve convergence in your analysis.
 
-{% comment %}{% include keywords.html script=true %}{% endcomment %}
+- [Introduction to RevGadgets]({{ base.url }}/tutorials/intro/revgadgets) walks you through the use of RevGadgets, an R package that is an optional but convenient tool for postprocessing of RevBayes results.
+
+{% endaside %}
+
+{% aside Molecular phylogenetic inference %}
+
+This module is intended for users looking to infer a phylogenetic tree using molecular (DNA) data.
+Users will learn how to set up basic molecular evolution model, and be presented with more advanced
+tutorials to tailor their learning to their desired analyses.
+
+- Pre-requisites: **RevBayes fundamentals**.
+
+1. Theoretical background: [Understanding continuous-time Markov models]({{ base.url }}/tutorials/dice). This tutorial will get you up to speed with the theory behind molecular evolution models.
+2. Basic molecular phylogenetic inference: [Nucleotide substitution models]({{ base.url }}/tutorials/ctmc). This tutorial will walk you through a simple example of molecular phylogeny inference.
+
+- If interested in partitioning molecular data: [Partitioned data analysis]({{ base.url }}/tutorials/partition). 
+- If interested in choosing between models of molecular evolution:
+    1. [General introduction to model selection]({{ base.url }}/tutorials/model_selection_bayes_factors/bf_intro).
+    2. [Model selection for one locus]({{ base.url }}/tutorials/model_selection_bayes_factors/bf_subst_model).
+    3. [Model selection for partition models]({{ base.url }}/tutorials/model_selection_bayes_factors/bf_partition_model).
+
+By the end of this module, you should be able to infer a phylogenetic tree with a simple molecular 
+evolution model. Depending on your interests, you will also have learned about how to set up
+partitioned models, and choose the best models for your dataset.
+
+{% endaside %}
+
+{% aside Polymorphism-aware molecular phylogenetics %}
+
+This module is intended for users looking to infer a phylogenetic tree using molecular data including polymorphisms. Users will learn how to modify their molecular evolution models to account for the presence of polymorphisms in the dataset, including, if desired, balanced selection. Note that the tutorials in this module use code on a separate RevBayes branch, requiring users to run `git checkout dev_PoMo_SNP` within their local RevBayes repo before running analyses.
+
+- Pre-requisites: **RevBayes fundamentals**, **Molecular phylogenetic inference**.
+
+1. [Polymorphism-aware phylogenetic models]({{ base.url }}/tutorials/pomos).
+- If interested in including balancing selection in your model: [Polymorphism-aware phylogenetic models with balancing selection]({{ base.url }}/tutorials/pomobalance).
+
+{% endaside %}
+
+{% aside Morphological phylogenetic inference %}
+
+This module is intended for users looking to infer a phylogenetic tree using morphological data.
+Users will learn how to set up basic morphological evolution models, including for characters
+with more than two states.
+
+- Pre-requisites: **RevBayes fundamentals**.
+
+1. Theoretical background: [Understanding continuous-time Markov models]({{ base.url }}/tutorials/dice). This tutorial will get you up to speed with the theory behind morphological evolution models.
+2. Morphological phylogenetics with binary traits: [Tree inference with discrete morphology]({{ base.url }}/tutorials/morph_tree). This tutorial will walk you through a simple example of morphological phylogeny inference, using only binary (i.e. two-state) characters.
+3. Expanding your dataset: [Multistate characters]({{ base.url }}/tutorials/morph_tree/V2). This tutorial will teach you how to accommodate characters with more than two states in your morphological phylogenetics analyses.
+
+{% endaside %}
+
+{% aside Dating a phylogeny %}
+
+This module is intended for users looking to date a time-calibrated phylogenetic tree. Users will learn how to set up analyses using both molecular clocks and fossil data for node dating.
+
+- Pre-requisites: **RevBayes fundamentals**, and either **Molecular phylogenetic inference** or **Morphological phylogenetic inference**. Note that while the tutorials below use molecular models, it is straightforward to adapt the clock model to a morphological analysis.
+
+1. Master dating tutorial: [Dating trees]({{ base.url }}/tutorials/dating). This tutorial includes:
+- [Global molecular clocks]({{ base.url }}/tutorials/dating/global): The basics of molecular clocks.
+- [Uncorrelated relaxed clocks]({{ base.url }}/tutorials/dating/relaxed): More complex (and biologically realistic) molecular clocks.
+- [Node dating with fossils]({{ base.url }}/tutorials/dating/nodedate): Including fossil data for node dating. The master dating tutorial also links to a more advanced tip-dating tutorial (see the **Total-evidence analysis with tip-dating** module).
+2. Bringing it all together: [Relaxed clocks & time trees]({{ base.url }}/tutorials/clocks). This tutorial walks the user through a full analysis, including performing model selection between multiple clock models.
+
+- If interested in enforcing the relative order of nodes in your analysis: [Dating with relative constraints]({{ base.url }}/tutorials/relative_time_constraints).
+
+{% endaside %} 
+
+{% aside Estimating diversification rates %}
+
+This module is intended for users looking to infer rates of speciation and extinction. Users will learn how to set up analyses using models in the birth-death model family, including the use of fossil data. While most of the tutorials here assume a fixed phylogenetic tree, some recommendations are made to point the user towards the direction of joint estimation as well.
+
+- Pre-requisites: **RevBayes fundamentals**.
+
+1. Theoretical background: [Introduction to diversification rate estimation]({{ base.url }}/tutorials/divrate/div_rate_intro). This tutorial will walk you through the theory behind the birth-death models used in the following tutorials.
+2. Constant-rate models: [Simple diversification-rate estimation]({{ base.url }}/tutorials/divrate/simple). This tutorial will walk you through the basics of setting up a birth-death model for estimating rates of speciation and extinction from a fixed phylogenetic tree.
+
+The following tutorials are to be picked based on your intended analyses, as they lay out different hypotheses regarding diversification dynamics and how to set up a BD model to test those.
+- If interested in time-heterogeneous (or environmentally-dependent) diversification dynamics: [Episodic diversification rate estimation]({{ base.url }}/tutorials/divrate/ebd), [Environmental-dependent speciation and extinction rates]({{ base.url }}/tutorials/divrate/env).
+- If interested in mass-extinction estimation, including fossil taxa: [Mass-extinction estimation]({{ base.url }}/tutorials/divrate/efbdp_me).
+- If interested in jointly estimating topology and diversification rates: [Relaxed clocks & time-trees]({{ base.url }}/tutorials/clocks) (consider completing the **Molecular phylogenetic inference** and **Dating a phylogeny** modules).
+
+{% endaside %}
+
+{% aside Total-evidence analysis with tip-dating %}
+
+This module is intended for users looking to infer a time-calibrated phylogenetic tree with both molecular and fossil data, and fossil ages. 
+
+- Pre-requisites: **Dating a phylogeny** (and both **Molecular phylogenetic inference** and **Morphological phylogenetic inference**), and **Estimating diversification rates**.
+
+1. [The fossilized birth-death model]({{ base.url }}/tutorials/fbd/fbd_specimen). This tutorial will push you to put together the skills learned in many previous tutorials, including setting up molecular and morphological evolution, clock, and birth-death models.
+
+- If interested in more complex diversification dynamics, explore the advanced tutorials in **Estimating diversification rates**. Note that `dnFBDP` should be used instead of `dnBDP`/`dnEBDP`.
+
+{% endaside %}
+
+{% aside State-dependent diversification-rate estimation %}
+
+This module is intended for users looking to infer trait-dependent diversification rates using the state-dependent speciation and extinction (SSE) model family. As with **Estimating diversification rates**, the tutorials assume a fixed tree, but tips are included for joint estimation.
+
+- Pre-requisites: **RevBayes fundamentals**, and **Estimating diversification rates**.
+
+1. Theoretical background: [Background on state-dependent diversification-rate estimation]({{ base.url }}/tutorials/sse/bisse-intro). This tutorial will introduce you to the theory behind the SSE model family, building from the fundamentals on BD models you learned on the **Estimating diversification rates** module.
+2. Testing the effects of discrete traits on diversification: [State-dependent diversification with BiSSE and MuSSE]({{ base.url }}/tutorials/sse/bisse). This tutorial will walk you through the setup of the simplest SSE models: binary and multiple SSE (BiSSE and MuSSE), which are used to test the effects of binary and multiple state discrete traits on diversification, respectively.
+
+- If interested in testing whether unobserved effects might impact diversification for your data: [State-dependent diversification with hidden SSE (HiSSE)]({{ base.url }}/tutorials/sse/hisse).
+- If interested in the presence of cladogenetic state transitions: [State-dependent diversification with cladogenetic SSE (ClaSSE)]({{ base.url }}/tutorials/sse/classe).
+- If interested in the effect of chromosome number on diversification: [Chromosome evolution]({{ base.url }}/tutorials/chromo).
+- If interested in jointly estimating topology and state-dependent diversification rates, adapt [Relaxed clocks & time-trees]({{ base.url }}/tutorials/clocks) to use `dnCDBDP` or `dnGLHBDSP` instead of `dnBDP` (consider completing the **Molecular phylogenetic inference** and **Dating a phylogeny** modules).
+
+{% endaside %}

--- a/tutorials/sse/tests.txt
+++ b/tutorials/sse/tests.txt
@@ -1,0 +1,1 @@
+mcmc_BiSSE.Rev


### PR DESCRIPTION
Tutorial modules page is now the landing page when clicking the "Tutorials" tab. This will ensure users have a more contained and less overwhelming experience when first looking at the tutorials. The full tutorials page can still be found on (base.url)/all_tutorials, and is linked on the modules page.