### PR TITLE
Tiny fix to a script from the model selection tutorial

### DIFF
--- a/tutorials/model_selection_bayes_factors/scripts/model_average_primates_cytb.Rev
+++ b/tutorials/model_selection_bayes_factors/scripts/model_average_primates_cytb.Rev
@@ -80,11 +80,11 @@ moves.append( mvRandomGeometricWalk(model_indicator, weight=10.0, tune=FALSE) )
 Q := Q_vec[model_indicator]
 
 
-# Alternative approch
-#Q ~ dnMixture( values=Q_vec, probabilities=simplex(rep(1,Q_vec.size())) )
-#model_indicator := Q.getAllocationIndex()
+# # Alternative approach
+# Q ~ dnMixture( values=Q_vec, probabilities=simplex( rep(1,Q_vec.size()) ) )
+# model_indicator := Q.getAllocationIndex()
 #
-#moves.append( mvGibbsMixtureAllocation(Q, weight=2.0)
+# moves.append( mvGibbsMixtureAllocation(Q, weight=2.0) )
 
 #################################################
 # Define the model of among-site rate variation #


### PR DESCRIPTION
The [`model_average_primates_cytb.Rev`](https://github.com/revbayes/revbayes.github.io/blob/source/tutorials/model_selection_bayes_factors/scripts/model_average_primates_cytb.Rev) script attached to our [model selection tutorial](https://revbayes.github.io/tutorials/model_selection_bayes_factors/bf_subst_model_rj.html) contains a few lines of commented out code with an alternative implementation of rjMCMC sampling. The line that adds the `mvGibbsMixtureAllocation` move was missing a close paren. Not a big deal by any means (especially since the code is not shown in the tutorial itself), but since these four lines were [until](https://github.com/revbayes/revbayes/pull/709) [recently](https://github.com/revbayes/revbayes/pull/719) our only way to conduct fully general rjMCMC analyses, I thought I'd fix it. :-)