### PR TITLE
Simplify multifurcation resolution in the stepwise inference tutorial

### DIFF
--- a/tutorials/sequential_bayes/scripts/mcmc_ultrametric.Rev
+++ b/tutorials/sequential_bayes/scripts/mcmc_ultrametric.Rev
@@ -93,9 +93,7 @@ time_tree ~ dnBirthDeath(rootAge=root_time, lambda=birth_rate, mu=death_rate, ta
 unrooted_MAP_tree = readBranchLengthTrees("output/photinus_"+GENE+"_MAP.tre")[1]
 
 ## resolve the trifurcation at the root
-root_index = 2*unrooted_MAP_tree.ntips() - 2
-first_child = unrooted_MAP_tree.getDescendantTaxa( unrooted_MAP_tree.child( root_index, 1 ) )
-unrooted_MAP_tree.reroot( clade(first_child), makeBifurcating=TRUE)
+unrooted_MAP_tree.resolveMultifurcations(resolveRoot=TRUE)
 
 ## make the tree ultrametric and restore node indices
 ultrametric_MAP_tree = unrooted_MAP_tree.makeUltrametric()

--- a/tutorials/sequential_bayes/stepwise_dating.md
+++ b/tutorials/sequential_bayes/stepwise_dating.md
@@ -132,11 +132,9 @@ You could also use an externally rooted tree, which might be preferred.
 unrooted_MAP_tree = readBranchLengthTrees("output/photinus_COI_MAP.tre")[1]
 ```
 Since the tree comes from a non-clock analysis, it is unrooted, which is to say it has a trifurcation at the root.
-We want to make its root bifurcating, but it is not important to us exactly how we do it. Therefore, we will just grab the first of the three children of the root node and make it the outgroup:
+We want to make its root bifurcating, but it is not important to us exactly how we do it, so we will just resolve the trifurcation randomly:
 ```
-root_index = 2*unrooted_MAP_tree.ntips() - 2
-first_child = unrooted_MAP_tree.getDescendantTaxa( unrooted_MAP_tree.child( root_index, 1 ) )
-unrooted_MAP_tree.reroot( clade(first_child), makeBifurcating=TRUE)
+unrooted_MAP_tree.resolveMultifurcations(resolveRoot=TRUE)
 ```
 We also need to make the tree ultrametric:
 ```


### PR DESCRIPTION
In website PR #45, I modified the way the [stepwise dating tutorial](https://revbayes.github.io/tutorials/sequential_bayes/stepwise_dating) resolves the trifurcation at the "root" of an unrooted tree. This was because RevBayes PR [#618](https://github.com/revbayes/revbayes/pull/618) removed the `.makeBifurcating()` method which the tutorial originally used for that purpose. At the time, this forced us to use an alternative and rather circuitous way of accomplishing the same goal. However, RevBayes PR [#641](https://github.com/revbayes/revbayes/pull/641) introduced a new method called `.resolveMultifurcations()`, which allows us to do this with a single line of code, just like in the original tutorial. Here, I'm changing the tutorial (and the attached script) one more time to make use of this new method.