### PR TITLE
Change the name of the first argument to `Tree.reroot()`

### DIFF
--- a/tutorials/relative_time_constraints/index.md
+++ b/tutorials/relative_time_constraints/index.md
@@ -450,8 +450,8 @@ and variances. Internally, it is ensured that the indices are shared correctly.
 # Reroot and make bifurcating.
 rootId <- tree.getRootIndex()
 outgroup <- tree.getDescendantTaxa(rootId)
-mean_tree.reroot(clade=clade(outgroup), make_bifurcating=TRUE)
-var_tree.reroot(clade=clade(outgroup), make_bifurcating=TRUE)
+mean_tree.reroot(outgroup=clade(outgroup), make_bifurcating=TRUE)
+var_tree.reroot(outgroup=clade(outgroup), make_bifurcating=TRUE)
 
 # Renumber nodes.
 mean_tree.renumberNodes(tree)

--- a/tutorials/relative_time_constraints/scripts/2_mcmc_dating.rev
+++ b/tutorials/relative_time_constraints/scripts/2_mcmc_dating.rev
@@ -113,8 +113,8 @@ var_tree <- readTrees(var_tree_file)[1]
 # Reroot and make bifurcating.
 rootId <- tree.getRootIndex()
 outgroup <- tree.getDescendantTaxa(rootId)
-mean_tree.reroot(clade=clade(outgroup), make_bifurcating=TRUE)
-var_tree.reroot(clade=clade(outgroup), make_bifurcating=TRUE)
+mean_tree.reroot(outgroup=clade(outgroup), make_bifurcating=TRUE)
+var_tree.reroot(outgroup=clade(outgroup), make_bifurcating=TRUE)
 
 # Renumber nodes.
 mean_tree.renumberNodes(tree)


### PR DESCRIPTION
PR [#742](https://github.com/revbayes/revbayes/pull/742) in the main repo changed the name of the first argument of the `.reroot()` method of class `Tree` from `clade` to `outgroup`, because it now accepts not just `Clade` objects but also a `String` specifying the name of a single tip.  Since this change has made it into v1.3.0, this PR modifies the only tutorial available from the website where the arguments to `.reroot()` are matched by name.