### PR TITLE
Change taxon name in diversification rate estimation tutorial

### DIFF
--- a/tutorials/divrate/sampling.md
+++ b/tutorials/divrate/sampling.md
@@ -470,7 +470,7 @@ species.
     Galagidae             = clade("Galago_senegalensis",  "Otolemur_crassicaudatus", missing= 17)
     Lorisidae             = clade("Perodicticus_potto", "Loris_tardigradus", "Nycticebus_coucang", missing=6)
     Cheirogaleoidea       = clade("Cheirogaleus_major", "Microcebus_murinus", missing= 19)
-    Lemuridae             = clade("Lemur_catta", "Varecia_variegata_variegata", missing=17)
+    Lemuridae             = clade("Lemur_catta", "Varecia_variegata", missing=17)
     Lemuriformes          = clade(Lemuridae, Cheirogaleoidea, missing=29)
     Atelidae_Aotidae      = clade("Alouatta_palliata", "Aotus_trivirgatus", missing=30)
     NWM                   = clade(Atelidae_Aotidae,"Callicebus_donacophilus", "Saimiri_sciureus", "Cebus_albifrons", missing=93)


### PR DESCRIPTION
In the [tutorial for estimating diversification rates under incomplete taxon sampling](https://revbayes.github.io/tutorials/divrate/sampling), we at one point specify a clade containing a taxon called "Varecia_variegata_variegata". However, in the tree files attached to the tutorial ([`primates.tre`](https://revbayes.github.io/tutorials/divrate/data/primates.tre) and [`primates_tree.nex`](https://revbayes.github.io/tutorials/divrate/data/primates_tree.nex)), the name of the corresponding taxon lacks the subspecific epithet, i.e., the taxon is only referred to as "Varecia_variegata". This PR fixes the mismatch.