### PR TITLE
Remove the `num_taxa` argument from `.computeEntropy()`

### DIFF
--- a/tutorials/model_testing_ppred_inf/scripts/PosteriorPredictive_TreeSummary.Rev
+++ b/tutorials/model_testing_ppred_inf/scripts/PosteriorPredictive_TreeSummary.Rev
@@ -28,7 +28,7 @@ for ( i in 1:num_post_sims) {
     tree_length <- sim_tree_trace.computeTreeLengths()
 
     ## This calculates the entropy statistic
-    entropy <- sim_tree_trace.computeEntropy(credibleTreeSetSize=1.0,num_taxa=data.ntaxa(),verbose=FALSE)
+    entropy <- sim_tree_trace.computeEntropy(credibleTreeSetSize=1.0,verbose=FALSE)
     
     
     ## calculate the stuff we care about for a single pps posterior
@@ -73,7 +73,7 @@ rf_dists <- emp_tree_trace.computePairwiseRFDistances(credibleTreeSetSize=1.0,ve
 tree_length <- emp_tree_trace.computeTreeLengths()
 
 ## This calculates the entropy statistic
-entropy <- emp_tree_trace.computeEntropy(credibleTreeSetSize=1.0,num_taxa=data.ntaxa(),verbose=FALSE)
+entropy <- emp_tree_trace.computeEntropy(credibleTreeSetSize=1.0,verbose=FALSE)
 
 ## calculate the stuff we care about for a single posterior
 mean_rf = mean(rf_dists)

--- a/tutorials/model_testing_pps/pps_inference.md
+++ b/tutorials/model_testing_pps/pps_inference.md
@@ -449,7 +449,7 @@ Example topological test statistic calculations from a posterior distribution {%
 {% endfigure %}
 
 Since these values are calculated by iterating over the entire series of posterior predictive analyses
-they are a bit unweildy to run line by line. However, we will talk about some of the individual functions
+they are a bit unwieldy to run line by line. However, we will talk about some of the individual functions
 and how they work so if you wish you can develop your own test statistics at a later time.
 Here are some examples of these functions from the
 **PosteriorPredictive_TreeSummary.Rev** script:
@@ -469,7 +469,7 @@ Here are some examples of these functions from the
 > various topologies become increasingly uneven, entropy decreases causing the difference between the entropy of the prior and the 
 > posterior to increase. Equation $\ref{equation1}$.  
 
-```entropy <- sim_tree_trace.computeEntropy(credibleTreeSetSize=1.0,numTaxa=data.ntaxa(),verbose=FALSE)```
+```entropy <- sim_tree_trace.computeEntropy(credibleTreeSetSize=1.0,verbose=FALSE)```
 
 Assuming a uniform prior on topologies, the change in entropy can be calculated as:
 

--- a/tutorials/model_testing_pps/scripts/PosteriorPredictive_TreeSummary.Rev
+++ b/tutorials/model_testing_pps/scripts/PosteriorPredictive_TreeSummary.Rev
@@ -28,7 +28,7 @@ for ( i in 1:num_post_sims) {
     tree_length <- sim_tree_trace.computeTreeLengths()
 
     ## This calculates the entropy statistic
-    entropy <- sim_tree_trace.computeEntropy(credibleTreeSetSize=1.0,num_taxa=data.ntaxa(),verbose=FALSE)
+    entropy <- sim_tree_trace.computeEntropy(credibleTreeSetSize=1.0,verbose=FALSE)
     
     
     ## calculate the stuff we care about for a single pps posterior
@@ -73,7 +73,7 @@ rf_dists <- emp_tree_trace.computePairwiseRFDistances(credibleTreeSetSize=1.0,ve
 tree_length <- emp_tree_trace.computeTreeLengths()
 
 ## This calculates the entropy statistic
-entropy <- emp_tree_trace.computeEntropy(credibleTreeSetSize=1.0,num_taxa=data.ntaxa(),verbose=FALSE)
+entropy <- emp_tree_trace.computeEntropy(credibleTreeSetSize=1.0,verbose=FALSE)
 
 ## calculate the stuff we care about for a single posterior
 mean_rf = mean(rf_dists)


### PR DESCRIPTION
PR [#819](https://github.com/revbayes/revbayes/pull/819) in the main repo removed the `num_taxa` argument from the `.computeEntropy()` method of class `TraceTree`, since this piece of information is something we can automatically extract from the object on which the method is called. This PR deletes the now-unrecognized argument from all places in our tutorials where the method is invoked.

We could either merge this immediately, or wait until the changes to `TreeTrace` become part of the next release.