### PR TITLE
Remove `mvAddRemoveTip` from a tutorial

### DIFF
--- a/tutorials/mcmc/moves.md
+++ b/tutorials/mcmc/moves.md
@@ -207,7 +207,6 @@ Moves available in RevBayes for tree variables.
 
  |   **Move**      |        **Description**        |    **Citation**   |
  |:---------------:|:-----------------------------:|:-----------------:|
- |    `mvAddRemoveTip`    |                               |  {% cite  %} |
  |    `mvBranchLengthScale`    |                               |  {% cite  %} |
  |    `mvCollapseExpandFossilBranch`    |                               |  {% cite  %} |
  |    `mvEmpiricalTree`    |                               |  {% cite  %} |


### PR DESCRIPTION
The [tutorial on MCMC moves](https://revbayes.github.io/tutorials/mcmc/moves.html) lists `mvAddRemoveTip` in the table of moves operating on tree objects. This move was recently removed from the development version of RevBayes (see PR [#862](https://github.com/revbayes/revbayes/pull/862) in the main repo) because the Jacobian it returned was known to be incorrect in some circumstances, and because it was never intended to be available on the main branch in the first place. While the latest release (v1.3.1) still includes the move, we should probably do our best to hide it from the users rather than advertise its presence.