### PR TITLE
Create workflow to exclude pages from search engines

### DIFF
--- a/.github/workflows/search-exclude.yml
+++ b/.github/workflows/search-exclude.yml
@@ -1,0 +1,46 @@
+
+name: Exclude pages from search engines
+
+on:
+  dispatch:
+  workflow_run:
+    workflows: ["Check that website builds"]  # build.yml
+    types:
+      - completed
+
+permissions:
+  contents: write
+
+jobs:
+  add-noindex:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master branch
+        uses: actions/checkout@v5
+        with:
+          ref: master
+
+      - name: Insert robots meta tag if missing
+        run: |
+          FILE="tutorials/fbd/index.html"
+          TAG='<meta name="robots" content="noindex, nofollow"> <!--Exclude from search results until debugged-->'
+          
+          if grep -q "$TAG" "$FILE"; then
+            echo "Tag already present. Skipping."
+          else
+            echo "Adding robots meta tag to $FILE"
+            sed -i '6i\
+'"$TAG"'
+' "$FILE"
+          fi
+
+      - name: Commit and push changes
+        run: |
+          if ! git diff --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add tutorials/fbd/index.html
+            git            git commit -m "Add robots noindex meta tag to tutorials/fbd/index.html"
+            git push origin master
+          else
+            echo "No changes to commit."

--- a/.github/workflows/search-exclude.yml
+++ b/.github/workflows/search-exclude.yml
@@ -1,4 +1,3 @@
-
 name: Exclude pages from search engines
 
 on:
@@ -21,26 +20,44 @@ jobs:
           ref: master
 
       - name: Insert robots meta tag if missing
+        shell: bash
         run: |
           FILE="tutorials/fbd/index.html"
-          TAG='<meta name="robots" content="noindex, nofollow"> <!--Exclude from search results until debugged-->'
-          
-          if grep -q "$TAG" "$FILE"; then
-            echo "Tag already present. Skipping."
-          else
-            echo "Adding robots meta tag to $FILE"
-            sed -i '6i\
+          TAG='    <meta name="robots" content="noindex, nofollow"> <!--Exclude from search results until debugged-->'
+
+          if [[ ! -f "$FILE" ]]; then
+            echo "ERROR: $FILE not found"
+            exit 1
+          fi
+
+          # Check for existing robots noindex tag
+          if grep -qi 'meta[[:space:]]\+name="robots"[[:space:]]\+content="noindex,[[:space:]]*nofollow"' "$FILE"; then
+            echo "Robots noindex tag already present. Skipping."
+            exit 0
+          fi
+
+          # Insert after the first <head ...> line
+          if grep -qi '<head[^>]*>' "$FILE"; then
+            echo "Adding robots meta tag after <head> in $FILE"
+            sed -i '0,/<head[^>]*>/I{/<head[^>]*>/a\
 '"$TAG"'
-' "$FILE"
+}' "$FILE"
+          else
+            echo "WARNING: No <head> tag found in $FILE; not inserting."
+            exit 0
           fi
 
       - name: Commit and push changes
+        shell: bash
         run: |
-          if ! git diff --quiet; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add tutorials/fbd/index.html
-            git            git commit -m "Add robots noindex meta tag to tutorials/fbd/index.html"
-            git push origin master
-          else
+          if git diff --quiet; then
             echo "No changes to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add tutorials/fbd/index.html
+          git commit -m "Add robots noindex meta tag to tutorials/fbd/index.html"
+          git push origin master

--- a/.github/workflows/search-exclude.yml
+++ b/.github/workflows/search-exclude.yml
@@ -1,5 +1,4 @@
 name: Exclude pages from search engines
-
 on:
   workflow_dispatch:
   workflow_run:
@@ -19,17 +18,3 @@ jobs:
         with:
           ref: master
 
-      - name: Commit and push changes
-        shell: bash
-        run: |
-          if git diff --quiet; then
-            echo "No changes to commit."
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git add tutorials/fbd/index.html
-          git commit -m "Add robots noindex meta tag to tutorials/fbd/index.html"
-          git push origin master

--- a/.github/workflows/search-exclude.yml
+++ b/.github/workflows/search-exclude.yml
@@ -1,7 +1,7 @@
 name: Exclude pages from search engines
 
 on:
-  dispatch:
+  workflow_dispatch:
   workflow_run:
     workflows: ["Check that website builds"]  # build.yml
     types:
@@ -30,22 +30,20 @@ jobs:
             exit 1
           fi
 
-          # Check for existing robots noindex tag
-          if grep -qi 'meta[[:space:]]\+name="robots"[[:space:]]\+content="noindex,[[:space:]]*nofollow"' "$FILE"; then
+          # If any robots noindex,nofollow meta exists (ignore spacing/case), do nothing
+          if grep -Eqi '<meta[[:space:]]+name="robots"[[:space:]]+content="noindex,[[:space:]]*nofollow"' "$FILE"; then
             echo "Robots noindex tag already present. Skipping."
             exit 0
           fi
 
-          # Insert after the first <head ...> line
-          if grep -qi '<head[^>]*>' "$FILE"; then
-            echo "Adding robots meta tag after <head> in $FILE"
-            sed -i '0,/<head[^>]*>/I{/<head[^>]*>/a\
-'"$TAG"'
-}' "$FILE"
-          else
-            echo "WARNING: No <head> tag found in $FILE; not inserting."
-            exit 0
-          fi
+          # Insert TAG on a new line immediately after the first <head ...> line
+          awk -v tag="$TAG" '
+            BEGIN { IGNORECASE=1; inserted=0 }
+            !inserted && $0 ~ /<head[^>]*>/ { print; print tag; inserted=1; next }
+            { print }
+          ' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
+
+          echo "Inserted robots meta tag after <head>."
 
       - name: Commit and push changes
         shell: bash

--- a/.github/workflows/search-exclude.yml
+++ b/.github/workflows/search-exclude.yml
@@ -19,32 +19,6 @@ jobs:
         with:
           ref: master
 
-      - name: Insert robots meta tag if missing
-        shell: bash
-        run: |
-          FILE="tutorials/fbd/index.html"
-          TAG='    <meta name="robots" content="noindex, nofollow"> <!--Exclude from search results until debugged-->'
-
-          if [[ ! -f "$FILE" ]]; then
-            echo "ERROR: $FILE not found"
-            exit 1
-          fi
-
-          # If any robots noindex,nofollow meta exists (ignore spacing/case), do nothing
-          if grep -Eqi '<meta[[:space:]]+name="robots"[[:space:]]+content="noindex,[[:space:]]*nofollow"' "$FILE"; then
-            echo "Robots noindex tag already present. Skipping."
-            exit 0
-          fi
-
-          # Insert TAG on a new line immediately after the first <head ...> line
-          awk -v tag="$TAG" '
-            BEGIN { IGNORECASE=1; inserted=0 }
-            !inserted && $0 ~ /<head[^>]*>/ { print; print tag; inserted=1; next }
-            { print }
-          ' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
-
-          echo "Inserted robots meta tag after <head>."
-
       - name: Commit and push changes
         shell: bash
         run: |


### PR DESCRIPTION
This workflow adds a 'noindex' meta tag to the FBD tutorial if it is missing, preventing search engines from indexing the page.