### PR TITLE
optimize Jekyll partial rendering with include_cached

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "observer"
 group :jekyll_plugins do
   gem 'jekyll-scholar'
   gem 'jekyll-last-modified-at'
+  gem 'jekyll-include-cache'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
+    jekyll-include-cache (0.2.1)
+      jekyll (>= 3.7, < 5.0)
     jekyll-last-modified-at (1.3.2)
       jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (3.1.0)
@@ -209,6 +211,7 @@ DEPENDENCIES
   base64
   csv
   jekyll
+  jekyll-include-cache
   jekyll-last-modified-at
   jekyll-scholar
   observer

--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ baseurl: ""
 helpdir: "documentation"
 version: v1.4.0
 
-plugins: ['jekyll/scholar']
+plugins: ['jekyll/scholar', 'jekyll-include-cache']
 
 include: [.nojekyll]
 exclude:

--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -6,9 +6,9 @@
 <script type="text/javascript">
 // Add default language
 $(":not(code).highlighter-rouge").each(function() {
-  {% if page.code_layout %}
+  {% if include.code_layout %}
   if( this.classList == "highlighter-rouge") {
-    this.classList = "{{ page.code_layout }} highlighter-rouge";
+    this.classList = "{{ include.code_layout }} highlighter-rouge";
   }
   {% endif %}
 });

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -2,7 +2,7 @@
   <div class="container-fluid">
     <div class="navbar-header">
       <a href="{{ site.baseurl }}{% link index.md %}" class="pull-left">
-        {% if page.title == 404 %}
+        {% if include.is_404 %}
         <img class="navbar-logo" src="{{ site.baseurl }}{% link assets/img/rbs.png %}" alt="RevBayes Home" />
         {% else %}
         <img class="navbar-logo" src="{{ site.baseurl }}{% link assets/img/aquabayes-desaturated.png %}" alt="RevBayes Home" />

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,14 +20,19 @@
   </head>
   <body>
     <div class="container">
-      {% include navbar.html %}
+      {% if page.title == 404 %}
+        {% assign is_404 = true %}
+      {% else %}
+        {% assign is_404 = false %}
+      {% endif %}
+      {% include_cached navbar.html is_404=is_404 %}
       <!-- adds margin to main content -->
       <div class="container" style="padding-left:20px padding-right:20px;">
           {{content}}
       </div>
-      {% include footer.html %}
+      {% include_cached footer.html %}
     </div>
-    {% include javascript.html %}
-    {% include analytics.html %}
+    {% include_cached javascript.html code_layout=page.code_layout %}
+    {% include_cached analytics.html %}
   </body>
 </html>

--- a/_layouts/help.html
+++ b/_layouts/help.html
@@ -6,7 +6,7 @@ code_layout: Rev
 
 <div class="row">
 
-{% include help_index.html %}
+{% include_cached help_index.html %}
 
 <div class="help col-sm-8">
     {% if page.entry %}

--- a/_plugins/filters.rb
+++ b/_plugins/filters.rb
@@ -17,6 +17,11 @@ module RevBayes
 
         file_string = file_identifier.sub(/^(?!\/)/,'/').sub(/^(\/tutorials)?\//,'/').gsub(/\//,'\/')
         
+        site.config['file_match_cache'] ||= {}
+        if hit = site.config['file_match_cache'][file_string]
+          return hit
+        end
+
         matches = site.static_files.find_all {|file| file.relative_path.match(Regexp.new(file_string)) }
 
         if matches.size > 1
@@ -24,6 +29,7 @@ module RevBayes
 Multiple files match '#{file_identifier}'
 MSG
         elsif matches.size > 0
+          site.config['file_match_cache'][file_string] = matches[0]
           return matches[0]
         end
         
@@ -45,6 +51,11 @@ MSG
         
         tag_string = @tag_name ? "tag '"+@tag_name+"'" : "filter 'match_page'"
 
+        site.config['page_match_cache'] ||= {}
+        if hit = site.config['page_match_cache'][page_string]
+          return hit
+        end
+
         matches = site.pages.find_all {|page| page.relative_path.match(Regexp.new(page_string)) }
 
         if matches.size > 1
@@ -52,6 +63,7 @@ MSG
 Multiple pages match '#{page_identifier}' in #{tag_string}
 MSG
         elsif matches.size > 0
+          site.config['page_match_cache'][page_string] = matches[0]
           return matches[0]
         end
         
@@ -83,7 +95,8 @@ MSG
           file = match_file(file)
         end
 
-        content = File.read(site.in_source_dir(file.path))
+        site.config['file_content_cache'] ||= {}
+        content = site.config['file_content_cache'][file.path] ||= File.read(site.in_source_dir(file.path))
 
         ret = ""
 
@@ -101,14 +114,15 @@ MSG
         range = from..to
 
         if type =~ /^line/
-          if to > content.lines.count
-            raise ArgumentError, <<-MSG
-Line number out of range in 'snippet' filter
-MSG
+          site.config['snippet_lines_filter_cache'] ||= {}
+          lines = site.config['snippet_lines_filter_cache'][file.path] ||= content.lines.to_a
+          
+          if to > lines.count
+            raise ArgumentError, "Line number out of range in 'snippet' filter"
           end
 
           i = 1
-          for line in content.each_line do
+          for line in lines do
             ret += line if range.include? i
             i += 1
           end
@@ -117,13 +131,21 @@ MSG
         elsif type =~ /^block/
           i = 1
           
-          if m = type.match(/block(.)$/)
-            content = content.gsub(Regexp.new('^\s*'+m[1]+'.*'),'')
+          site.config['snippet_blocks_cache'] ||= {}
+          cache_key = "#{file.path}_#{type}"
+          
+          blocks = site.config['snippet_blocks_cache'][cache_key]
+          if blocks.nil?
+            processed_content = content.dup
+            if m = type.match(/block(.)$/)
+              processed_content = processed_content.gsub(Regexp.new('^\s*'+m[1]+'.*'),'')
+            end
+            processed_content = processed_content.gsub(/\A\n*/m,'')
+            blocks = processed_content.gsub(/\n\n+/m,"\n\n").each_line("\n\n").to_a
+            site.config['snippet_blocks_cache'][cache_key] = blocks
           end
 
-          content = content.gsub(/\A\n*/m,'')
-
-          for block in content.gsub(/\n\n+/m,"\n\n").each_line("\n\n") do
+          for block in blocks do
             ret += block if range.include? i
             i += 1
           end
@@ -143,7 +165,8 @@ MSG
           file = match_file(file)
         end
 
-        content = File.read(site.in_source_dir(file.path))
+        site.config['file_content_cache'] ||= {}
+        content = site.config['file_content_cache'][file.path] ||= File.read(site.in_source_dir(file.path))
 
         ret = ""
 

--- a/_plugins/snippet.rb
+++ b/_plugins/snippet.rb
@@ -23,7 +23,9 @@ module Liquid
         raise IOError, "❌ Error: File '#{@filename}' not found at #{file_path}."
       end
 
-      file_lines = File.readlines(file_path).map{ |l| l.strip }
+      site = context.registers[:site]
+      site.config['snippet_lines_cache'] ||= {}
+      file_lines = site.config['snippet_lines_cache'][file_path] ||= File.readlines(file_path).map{ |l| l.strip }
 
       check_sequence(code_lines, file_lines, code_block)
 


### PR DESCRIPTION
With Antigravity's help, I tried speeding up our site build. 

### Changes:
1. Included `jekyll-include-cache` plugin that converts frequently used includes to include_cached.
2. Snippet blocks are now cached in memory during the build process, so every snippet call does not have to go to the Rev script multiple times. 

#### Before:
`done in 143.483 seconds.`

#### After:
`done in 64.18 seconds.`

### Checks:
GitHub Actions should always do a fresh build, so it would generate the expected site we already have. 
In my test, going through a few pages (especially the 404 error and the documentation pages), it didn't seem to break anything.