### PR TITLE
Revert "Simplify multifurcation resolution in the stepwise inference tutorial"

### DIFF
--- a/tutorials/sequential_bayes/scripts/mcmc_ultrametric.Rev
+++ b/tutorials/sequential_bayes/scripts/mcmc_ultrametric.Rev
@@ -93,7 +93,9 @@ time_tree ~ dnBirthDeath(rootAge=root_time, lambda=birth_rate, mu=death_rate, ta
 unrooted_MAP_tree = readBranchLengthTrees("output/photinus_"+GENE+"_MAP.tre")[1]
 
 ## resolve the trifurcation at the root
-unrooted_MAP_tree.resolveMultifurcations(resolveRoot=TRUE)
+root_index = 2*unrooted_MAP_tree.ntips() - 2
+first_child = unrooted_MAP_tree.getDescendantTaxa( unrooted_MAP_tree.child( root_index, 1 ) )
+unrooted_MAP_tree.reroot( clade(first_child), makeBifurcating=TRUE)
 
 ## make the tree ultrametric and restore node indices
 ultrametric_MAP_tree = unrooted_MAP_tree.makeUltrametric()

--- a/tutorials/sequential_bayes/stepwise_dating.md
+++ b/tutorials/sequential_bayes/stepwise_dating.md
@@ -132,9 +132,11 @@ You could also use an externally rooted tree, which might be preferred.
 unrooted_MAP_tree = readBranchLengthTrees("output/photinus_COI_MAP.tre")[1]
 ```
 Since the tree comes from a non-clock analysis, it is unrooted, which is to say it has a trifurcation at the root.
-We want to make its root bifurcating, but it is not important to us exactly how we do it, so we will just resolve the trifurcation randomly:
+We want to make its root bifurcating, but it is not important to us exactly how we do it. Therefore, we will just grab the first of the three children of the root node and make it the outgroup:
 ```
-unrooted_MAP_tree.resolveMultifurcations(resolveRoot=TRUE)
+root_index = 2*unrooted_MAP_tree.ntips() - 2
+first_child = unrooted_MAP_tree.getDescendantTaxa( unrooted_MAP_tree.child( root_index, 1 ) )
+unrooted_MAP_tree.reroot( clade(first_child), makeBifurcating=TRUE)
 ```
 We also need to make the tree ultrametric:
 ```


### PR DESCRIPTION
Reverts revbayes/revbayes.github.io#55.

This is a temporary solution to make the tutorial work with the current version of RevBayes (v1.4.0), before we find a more elegant way of rooting unrooted trees and integrate it into the next release.